### PR TITLE
feat: implement individual session publishing to Teams and update related DTOs

### DIFF
--- a/src/backend/Features/Series/Dtos/SeriesListItemDto.cs
+++ b/src/backend/Features/Series/Dtos/SeriesListItemDto.cs
@@ -1,10 +1,12 @@
 namespace EdgeFront.Builder.Features.Series.Dtos;
 
+// TODO-SPEC: DraftSessionCount not yet defined in SPEC-110; added to support Partially Published display.
 public record SeriesListItemDto(
     Guid SeriesId,
     string Title,
     string Status,
     int SessionCount,
+    int DraftSessionCount,
     int TotalRegistrations,
     int TotalAttendees,
     int UniqueAccountsInfluenced,

--- a/src/backend/Features/Series/Dtos/SeriesResponseDto.cs
+++ b/src/backend/Features/Series/Dtos/SeriesResponseDto.cs
@@ -1,8 +1,10 @@
 namespace EdgeFront.Builder.Features.Series.Dtos;
 
+// TODO-SPEC: DraftSessionCount not yet defined in SPEC-110; added to support Partially Published display.
 public record SeriesResponseDto(
     Guid SeriesId,
     string Title,
     string Status,
+    int DraftSessionCount,
     DateTime CreatedAt,
     DateTime UpdatedAt);

--- a/src/backend/Features/Series/SeriesService.cs
+++ b/src/backend/Features/Series/SeriesService.cs
@@ -36,6 +36,12 @@ public class SeriesService
             .Select(g => new { SeriesId = g.Key, Count = g.Count() })
             .ToDictionaryAsync(x => x.SeriesId, x => x.Count);
 
+        var draftSessionCounts = await _db.Sessions
+            .Where(s => seriesIds.Contains(s.SeriesId) && s.Status == SessionStatus.Draft)
+            .GroupBy(s => s.SeriesId)
+            .Select(g => new { SeriesId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.SeriesId, x => x.Count);
+
         return series.Select(s =>
         {
             var m = metrics.TryGetValue(s.SeriesId, out var sm) ? sm : null;
@@ -44,6 +50,7 @@ public class SeriesService
                 s.Title,
                 s.Status.ToString(),
                 sessionCounts.TryGetValue(s.SeriesId, out var count) ? count : 0,
+                draftSessionCounts.TryGetValue(s.SeriesId, out var draftCount) ? draftCount : 0,
                 m?.TotalRegistrations ?? 0,
                 m?.TotalAttendees ?? 0,
                 m?.UniqueAccountsInfluenced ?? 0,
@@ -57,7 +64,11 @@ public class SeriesService
     {
         var series = await _db.Series
             .FirstOrDefaultAsync(s => s.SeriesId == id && s.OwnerUserId == ownerUserId);
-        return series is null ? null : ToResponseDto(series);
+        if (series is null) return null;
+
+        var draftCount = await _db.Sessions
+            .CountAsync(s => s.SeriesId == id && s.Status == SessionStatus.Draft);
+        return ToResponseDto(series, draftCount);
     }
 
     public async Task<SeriesResponseDto> CreateAsync(CreateSeriesRequest req, string ownerUserId)
@@ -74,7 +85,7 @@ public class SeriesService
 
         _db.Series.Add(series);
         await _db.SaveChangesAsync();
-        return ToResponseDto(series);
+        return ToResponseDto(series, draftSessionCount: 0);
     }
 
     public async Task<SeriesResponseDto?> UpdateAsync(Guid id, UpdateSeriesRequest req, string ownerUserId)
@@ -86,7 +97,10 @@ public class SeriesService
         series.Title = req.Title;
         series.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
-        return ToResponseDto(series);
+
+        var draftCount = await _db.Sessions
+            .CountAsync(s => s.SeriesId == id && s.Status == SessionStatus.Draft);
+        return ToResponseDto(series, draftCount);
     }
 
     public async Task<bool> DeleteAsync(Guid id, string ownerUserId)
@@ -143,7 +157,7 @@ public class SeriesService
                 s.LastSyncAt = DateTime.UtcNow;
             }
             await _db.SaveChangesAsync();
-            return (ToResponseDto(series), null);
+            return (ToResponseDto(series, draftSessionCount: 0), null);
         }
 
         // 3. Create and publish webinars in Teams; track created IDs for rollback
@@ -177,7 +191,7 @@ public class SeriesService
             }
 
             await _db.SaveChangesAsync();
-            return (ToResponseDto(series), null);
+            return (ToResponseDto(series, draftSessionCount: 0), null);
         }
         catch (TeamsLicenseException lex)
         {
@@ -219,6 +233,6 @@ public class SeriesService
         return allOk;
     }
 
-    private static SeriesResponseDto ToResponseDto(Domain.Entities.Series s) =>
-        new(s.SeriesId, s.Title, s.Status.ToString(), s.CreatedAt, s.UpdatedAt);
+    private static SeriesResponseDto ToResponseDto(Domain.Entities.Series s, int draftSessionCount = 0) =>
+        new(s.SeriesId, s.Title, s.Status.ToString(), draftSessionCount, s.CreatedAt, s.UpdatedAt);
 }

--- a/src/backend/Features/Sessions/SessionEndpoints.cs
+++ b/src/backend/Features/Sessions/SessionEndpoints.cs
@@ -118,6 +118,36 @@ public static class SessionEndpoints
                     "session_not_found", "Session not found.", ctx.TraceIdentifier));
         });
 
+        // TODO-SPEC: POST /sessions/{id}/publish not yet in SPEC-110; added for incremental session publish.
+        sessionGroup.MapPost("/{id:guid}/publish", async (Guid id, SessionService service, ITeamsGraphClient graphClient, IOboTokenService oboService, HttpContext ctx, ILoggerFactory loggerFactory) =>
+        {
+            var logger = loggerFactory.CreateLogger("SessionEndpoints");
+            var userId = ctx.GetUserOid();
+            if (userId is null)
+                return Results.Unauthorized();
+
+            var oboToken = await TryGetOboTokenAsync(ctx, oboService);
+
+            var (session, errorCode) = await service.PublishAsync(id, userId, oboToken, graphClient, logger);
+            if (session is null)
+            {
+                if (errorCode == "session_not_found")
+                    return Results.NotFound(new ErrorEnvelope(
+                        errorCode, "Session not found.", ctx.TraceIdentifier));
+                if (errorCode is "SESSION_ALREADY_PUBLISHED" or "SERIES_NOT_PUBLISHED")
+                    return Results.BadRequest(new ErrorEnvelope(
+                        errorCode, errorCode == "SESSION_ALREADY_PUBLISHED"
+                            ? "Session is already published."
+                            : "Series must be published before publishing individual sessions.",
+                        ctx.TraceIdentifier));
+
+                return Results.UnprocessableEntity(new ErrorEnvelope(
+                    errorCode ?? "SESSION_PUBLISH_FAILED", "Session publish failed.", ctx.TraceIdentifier));
+            }
+
+            return Results.Ok(session);
+        });
+
         // Sync session data from Teams (user-initiated, delegated)
         sessionGroup.MapPost("/{id:guid}/sync", async (Guid id, SyncService syncService, IOboTokenService oboService, HttpContext ctx, ILoggerFactory loggerFactory) =>
         {

--- a/src/backend/Features/Sessions/SessionService.cs
+++ b/src/backend/Features/Sessions/SessionService.cs
@@ -155,6 +155,95 @@ public class SessionService
         return true;
     }
 
+    // TODO-SPEC: Session-level publish not yet defined in SPEC-110; added to support
+    // publishing individual Draft sessions after a series has already been published.
+    /// <summary>
+    /// Publish a single Draft session within an already-Published series.
+    /// Creates a Teams webinar, publishes it, and transitions the session to Published.
+    /// </summary>
+    public async Task<(SessionResponseDto? session, string? errorCode)> PublishAsync(
+        Guid sessionId, string ownerUserId,
+        string? oboToken = null, ITeamsGraphClient? graphClient = null, ILogger? logger = null)
+    {
+        logger ??= NullLogger.Instance;
+
+        var session = await _db.Sessions
+            .FirstOrDefaultAsync(s => s.SessionId == sessionId && s.OwnerUserId == ownerUserId);
+        if (session is null)
+            return (null, "session_not_found");
+
+        if (session.Status == SessionStatus.Published)
+            return (null, "SESSION_ALREADY_PUBLISHED");
+
+        // Verify the parent series is Published
+        var series = await _db.Series
+            .FirstOrDefaultAsync(s => s.SeriesId == session.SeriesId && s.OwnerUserId == ownerUserId);
+        if (series is null)
+            return (null, "series_not_found");
+        if (series.Status != SeriesStatus.Published)
+            return (null, "SERIES_NOT_PUBLISHED");
+
+        // Stub path: no graph client → flip status without Teams interaction
+        if (graphClient is null || string.IsNullOrEmpty(oboToken))
+        {
+            session.Status = SessionStatus.Published;
+            session.ReconcileStatus = ReconcileStatus.Synced;
+            session.LastSyncAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+            return (ToResponseDto(session), null);
+        }
+
+        // Create and publish the Teams webinar
+        string? createdWebinarId = null;
+        try
+        {
+            createdWebinarId = await graphClient.CreateWebinarAsync(
+                session.Title,
+                new DateTimeOffset(session.StartsAt, TimeSpan.Zero),
+                new DateTimeOffset(session.EndsAt, TimeSpan.Zero),
+                oboToken);
+
+            await graphClient.PublishWebinarAsync(createdWebinarId, oboToken);
+
+            session.TeamsWebinarId = createdWebinarId;
+            session.Status = SessionStatus.Published;
+            session.ReconcileStatus = ReconcileStatus.Synced;
+            session.LastSyncAt = DateTime.UtcNow;
+
+            await _db.SaveChangesAsync();
+            return (ToResponseDto(session), null);
+        }
+        catch (TeamsLicenseException lex)
+        {
+            logger.LogWarning(lex, "Teams license required during session publish. SessionId={SessionId}", sessionId);
+            await RollbackWebinarAsync(graphClient, oboToken, createdWebinarId, logger);
+            return (null, "TEAMS_LICENSE_REQUIRED");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Session publish failed. SessionId={SessionId}", sessionId);
+            var rollbackOk = await RollbackWebinarAsync(graphClient, oboToken, createdWebinarId, logger);
+            return (null, rollbackOk ? "SESSION_PUBLISH_FAILED" : "SESSION_PUBLISH_PARTIAL_FAILURE");
+        }
+    }
+
+    private static async Task<bool> RollbackWebinarAsync(
+        ITeamsGraphClient graphClient, string oboToken, string? webinarId, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(webinarId)) return true;
+
+        try
+        {
+            await graphClient.DeleteWebinarAsync(webinarId, oboToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Rollback: failed to delete webinar {WebinarId}", webinarId);
+            return false;
+        }
+    }
+
     private static SessionResponseDto ToResponseDto(Session s) =>
         new(s.SessionId, s.SeriesId, s.Title, s.StartsAt, s.EndsAt,
             s.Status.ToString(), s.TeamsWebinarId,

--- a/src/frontend/app/sessions/[id]/page.tsx
+++ b/src/frontend/app/sessions/[id]/page.tsx
@@ -4,14 +4,14 @@ import { useState, useEffect, useCallback } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
-import { ChevronLeft, AlertTriangle, Save, Trash2, RefreshCw, ExternalLink } from 'lucide-react'
+import { ChevronLeft, AlertTriangle, Save, Trash2, RefreshCw, ExternalLink, Rocket } from 'lucide-react'
 import { ErrorBanner } from '@/components/error-banner'
 import { StatusBadge } from '@/components/status-badge'
 import { MetricsPanel } from '@/components/metrics-panel'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 
 import { getSessionById } from '@/lib/api/sessions'
-import { updateSession, deleteSession, syncSession } from '@/lib/api/sessions'
+import { updateSession, deleteSession, syncSession, publishSession } from '@/lib/api/sessions'
 import { getSessionMetrics } from '@/lib/api/metrics'
 import type { SessionResponse, SessionMetricsResponse } from '@/lib/api/types'
 
@@ -186,6 +186,33 @@ export default function SessionDetailPage() {
       setDeleteError(err instanceof Error ? err.message : 'Failed to delete session')
       setDeleteLoading(false)
       setDeleteOpen(false)
+    }
+  }
+
+  // ── Publish individual session to Teams ──────────────────────────────────
+  const [publishOpen, setPublishOpen] = useState(false)
+  const [publishLoading, setPublishLoading] = useState(false)
+  const [publishError, setPublishError] = useState<string | null>(null)
+  const [publishLicenseError, setPublishLicenseError] = useState(false)
+
+  async function handlePublishSession() {
+    setPublishLoading(true)
+    setPublishError(null)
+    setPublishLicenseError(false)
+    try {
+      await publishSession(id, token)
+      setPublishOpen(false)
+      setPublishLoading(false)
+      loadData()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Session publish failed'
+      if (msg.includes('TEAMS_LICENSE_REQUIRED')) {
+        setPublishLicenseError(true)
+      } else {
+        setPublishError(msg)
+      }
+      setPublishLoading(false)
+      setPublishOpen(false)
     }
   }
 
@@ -367,6 +394,21 @@ export default function SessionDetailPage() {
 
       {deleteError && <ErrorBanner message={deleteError} />}
       {saveError && <ErrorBanner message={saveError} />}
+      {publishError && (
+        <ErrorBanner
+          message={publishError}
+          onRetry={() => { setPublishError(null); setPublishOpen(true) }}
+        />
+      )}
+      {publishLicenseError && (
+        <div
+          role="alert"
+          className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          <strong>Teams webinar license required.</strong> Cannot publish session — assign a Teams
+          webinar license, then retry.
+        </div>
+      )}
       {teamsUpdateFailed && (
         <div
           role="alert"
@@ -473,6 +515,17 @@ export default function SessionDetailPage() {
               <Save className="size-4" aria-hidden="true" />
               {saveLabel}
             </button>
+            {!isPublished && (
+              <button
+                type="button"
+                onClick={() => { setPublishError(null); setPublishLicenseError(false); setPublishOpen(true) }}
+                disabled={publishLoading}
+                className="inline-flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-800 hover:bg-amber-100 disabled:opacity-50"
+              >
+                <Rocket className="size-4" aria-hidden="true" />
+                Publish to Teams
+              </button>
+            )}
             <Link
               href={`/series/${session.seriesId}`}
               className="rounded-md border px-4 py-2 text-sm hover:bg-muted transition-colors"
@@ -535,6 +588,17 @@ export default function SessionDetailPage() {
         loading={deleteLoading}
         onConfirm={handleDelete}
         onCancel={() => setDeleteOpen(false)}
+      />
+
+      {/* ── Publish Session Confirm ──────────────────────────────────────── */}
+      <ConfirmDialog
+        open={publishOpen}
+        title="Publish Session to Teams"
+        description="This will create a Teams webinar for this session. Continue?"
+        confirmLabel="Publish"
+        loading={publishLoading}
+        onConfirm={handlePublishSession}
+        onCancel={() => setPublishOpen(false)}
       />
     </div>
   )

--- a/src/frontend/components/series-detail-view.tsx
+++ b/src/frontend/components/series-detail-view.tsx
@@ -10,7 +10,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { MetricsPanel } from '@/components/metrics-panel'
 import { updateSeries, deleteSeries, publishSeries, syncSeries } from '@/lib/api/series'
-import { deleteSession } from '@/lib/api/sessions'
+import { deleteSession, publishSession } from '@/lib/api/sessions'
 import type { SeriesResponse, SessionListItem, SeriesMetricsResponse } from '@/lib/api/types'
 
 function formatDateTime(iso: string | null | undefined) {
@@ -180,6 +180,38 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
     }
   }
 
+  // ── Publish Session (individual) ──────────────────────────────────────────
+  const [publishSessionId, setPublishSessionId] = useState<string | null>(null)
+  const [publishSessionLoading, setPublishSessionLoading] = useState(false)
+  const [publishSessionError, setPublishSessionError] = useState<string | null>(null)
+  const [publishSessionLicenseError, setPublishSessionLicenseError] = useState(false)
+
+  async function handlePublishSession() {
+    if (!publishSessionId) return
+    setPublishSessionLoading(true)
+    setPublishSessionError(null)
+    setPublishSessionLicenseError(false)
+    try {
+      await publishSession(publishSessionId, token)
+      setPublishSessionId(null)
+      router.refresh()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Session publish failed'
+      if (msg.includes('TEAMS_LICENSE_REQUIRED')) {
+        setPublishSessionLicenseError(true)
+      } else {
+        setPublishSessionError(msg)
+      }
+      setPublishSessionLoading(false)
+      setPublishSessionId(null)
+    }
+  }
+
+  const seriesDisplayStatus =
+    series.status === 'Published' && series.draftSessionCount > 0
+      ? 'Partially Published'
+      : series.status
+
   return (
     <div className="space-y-6">
       {/* ── Header ──────────────────────────────────────────────────────── */}
@@ -196,7 +228,7 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
             >
               <Pencil className="size-4" aria-hidden="true" />
             </button>
-            <StatusBadge status={series.status} />
+            <StatusBadge status={seriesDisplayStatus} />
           </div>
           <p className="text-xs text-muted-foreground">
             Created {formatDateTime(series.createdAt)} · Updated {formatDateTime(series.updatedAt)}
@@ -249,6 +281,21 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
           service account, then retry publishing.
         </div>
       )}
+      {publishSessionError && (
+        <ErrorBanner
+          message={publishSessionError}
+          onRetry={() => { setPublishSessionError(null) }}
+        />
+      )}
+      {publishSessionLicenseError && (
+        <div
+          role="alert"
+          className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          <strong>Teams webinar license required.</strong> Cannot publish session — assign a Teams
+          webinar license, then retry.
+        </div>
+      )}
 
       {/* ── Metrics ──────────────────────────────────────────────────────── */}
       <section aria-label="Series metrics">
@@ -288,6 +335,11 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
             <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               Sessions ({sessions.length})
             </h2>
+            {series.status === 'Published' && series.draftSessionCount > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                {series.draftSessionCount} unpublished
+              </span>
+            )}
             {syncing && (
               <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span className="size-3 rounded-full border-2 border-primary/30 border-t-primary animate-spin" aria-hidden="true" />
@@ -374,7 +426,19 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
                       onClick={(e) => e.stopPropagation()}
                     >
                       <div className="flex items-center justify-end gap-1">
-                        {s.teamsWebinarId && (
+                        {series.status === 'Published' && s.status === 'Draft' && (
+                          <button
+                            type="button"
+                            onClick={() => setPublishSessionId(s.sessionId)}
+                            disabled={publishSessionLoading}
+                            className="rounded p-1 text-amber-600 hover:text-amber-800 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                            aria-label={`Publish ${s.title} to Teams`}
+                            title="Publish to Teams"
+                          >
+                            <Rocket className="size-3.5" />
+                          </button>
+                        )}
+                        {s.status === 'Published' && s.teamsWebinarId && (
                           <a
                             href={`https://teams.microsoft.com/l/virtual-event/${s.teamsWebinarId}`}
                             target="_blank"
@@ -502,6 +566,17 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
         loading={deleteSessionLoading}
         onConfirm={handleDeleteSession}
         onCancel={() => setDeleteSessionId(null)}
+      />
+
+      {/* ── Publish Session Confirm ───────────────────────────────────────── */}
+      <ConfirmDialog
+        open={publishSessionId !== null}
+        title="Publish Session to Teams"
+        description="This will create a Teams webinar for this session. Continue?"
+        confirmLabel="Publish"
+        loading={publishSessionLoading}
+        onConfirm={handlePublishSession}
+        onCancel={() => setPublishSessionId(null)}
       />
     </div>
   )

--- a/src/frontend/components/series-list-content.tsx
+++ b/src/frontend/components/series-list-content.tsx
@@ -19,7 +19,7 @@ function SeriesTableRow({ item }: { item: SeriesListItem }) {
         </Link>
       </td>
       <td className="px-4 py-3">
-        <StatusBadge status={item.status} />
+        <StatusBadge status={item.status === 'Published' && item.draftSessionCount > 0 ? 'Partially Published' : item.status} />
       </td>
       <td className="px-4 py-3 tabular-nums text-right">{item.sessionCount}</td>
       <td className="px-4 py-3 tabular-nums text-right">{item.totalRegistrations}</td>

--- a/src/frontend/components/status-badge.tsx
+++ b/src/frontend/components/status-badge.tsx
@@ -8,6 +8,7 @@ interface StatusBadgeProps {
 const statusStyles: Record<string, string> = {
   Draft: 'bg-stone-100 text-stone-700 border-stone-200',
   Published: 'bg-green-50 text-green-700 border-green-200',
+  'Partially Published': 'bg-amber-50 text-amber-700 border-amber-200',
   // Fallback for unknown values
   default: 'bg-gray-100 text-gray-700 border-gray-200',
 }

--- a/src/frontend/lib/api/sessions.ts
+++ b/src/frontend/lib/api/sessions.ts
@@ -56,3 +56,14 @@ export async function syncSession(
     accessToken,
   )
 }
+
+export async function publishSession(
+  id: string,
+  accessToken: string,
+): Promise<SessionResponse> {
+  return apiFetch<SessionResponse>(
+    `/sessions/${id}/publish`,
+    { method: 'POST' },
+    accessToken,
+  )
+}

--- a/src/frontend/lib/api/types.ts
+++ b/src/frontend/lib/api/types.ts
@@ -3,6 +3,7 @@ export interface SeriesListItem {
   title: string
   status: 'Draft' | 'Published'
   sessionCount: number
+  draftSessionCount: number
   totalRegistrations: number
   totalAttendees: number
   uniqueAccountsInfluenced: number
@@ -15,6 +16,7 @@ export interface SeriesResponse {
   seriesId: string
   title: string
   status: 'Draft' | 'Published'
+  draftSessionCount: number
   createdAt: string
   updatedAt: string
 }

--- a/tests/backend/EdgeFront.Builder.Tests/Features/Sessions/SessionPublishTests.cs
+++ b/tests/backend/EdgeFront.Builder.Tests/Features/Sessions/SessionPublishTests.cs
@@ -1,0 +1,223 @@
+using EdgeFront.Builder.Domain;
+using EdgeFront.Builder.Domain.Entities;
+using EdgeFront.Builder.Features.Sessions;
+using EdgeFront.Builder.Infrastructure.Data;
+using EdgeFront.Builder.Infrastructure.Graph;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace EdgeFront.Builder.Tests.Features.Sessions;
+
+/// <summary>
+/// Tests for individual session publish (Draft → Published within an already-Published series).
+/// </summary>
+public class SessionPublishTests : IDisposable
+{
+    private readonly AppDbContext _db;
+    private readonly SessionService _sut;
+    private const string OwnerUserId = "pub-session-user";
+    private const string OboToken = "obo-test-token";
+
+    public SessionPublishTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _db = new AppDbContext(options);
+        _sut = new SessionService(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ─── Happy path ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_HappyPath_CreatesWebinarAndTransitionsStatus()
+    {
+        var (_, session) = await SeedPublishedSeriesWithDraftSessionAsync();
+
+        var graphMock = new Mock<ITeamsGraphClient>();
+        graphMock.Setup(g => g.CreateWebinarAsync(
+                session.Title, It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), OboToken, default))
+            .ReturnsAsync("webinar-session-1");
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId, OboToken, graphMock.Object, NullLogger.Instance);
+
+        errorCode.Should().BeNull();
+        result.Should().NotBeNull();
+        result!.Status.Should().Be("Published");
+        result.TeamsWebinarId.Should().Be("webinar-session-1");
+
+        var dbSession = await _db.Sessions.FindAsync(session.SessionId);
+        dbSession!.Status.Should().Be(SessionStatus.Published);
+        dbSession.TeamsWebinarId.Should().Be("webinar-session-1");
+        dbSession.ReconcileStatus.Should().Be(ReconcileStatus.Synced);
+        dbSession.LastSyncAt.Should().NotBeNull();
+
+        graphMock.Verify(g => g.PublishWebinarAsync("webinar-session-1", OboToken, default), Times.Once);
+    }
+
+    // ─── Already published ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_SessionAlreadyPublished_ReturnsError()
+    {
+        var (series, session) = await SeedPublishedSeriesWithDraftSessionAsync();
+        session.Status = SessionStatus.Published;
+        session.TeamsWebinarId = "existing-webinar";
+        await _db.SaveChangesAsync();
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId, OboToken, Mock.Of<ITeamsGraphClient>(), NullLogger.Instance);
+
+        result.Should().BeNull();
+        errorCode.Should().Be("SESSION_ALREADY_PUBLISHED");
+    }
+
+    // ─── Series not published ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_SeriesStillDraft_ReturnsError()
+    {
+        var series = new EdgeFront.Builder.Domain.Entities.Series
+        {
+            SeriesId = Guid.NewGuid(),
+            OwnerUserId = OwnerUserId,
+            Title = "Draft Series",
+            Status = SeriesStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _db.Series.Add(series);
+
+        var session = BuildDraftSession(series.SeriesId);
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId, OboToken, Mock.Of<ITeamsGraphClient>(), NullLogger.Instance);
+
+        result.Should().BeNull();
+        errorCode.Should().Be("SERIES_NOT_PUBLISHED");
+    }
+
+    // ─── Session not found ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_SessionNotFound_ReturnsError()
+    {
+        var (result, errorCode) = await _sut.PublishAsync(
+            Guid.NewGuid(), OwnerUserId, OboToken, Mock.Of<ITeamsGraphClient>(), NullLogger.Instance);
+
+        result.Should().BeNull();
+        errorCode.Should().Be("session_not_found");
+    }
+
+    // ─── License exception ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_LicenseException_ReturnsLicenseRequired_NoStatusChange()
+    {
+        var (_, session) = await SeedPublishedSeriesWithDraftSessionAsync();
+
+        var graphMock = new Mock<ITeamsGraphClient>();
+        graphMock.Setup(g => g.CreateWebinarAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), OboToken, default))
+            .ThrowsAsync(new TeamsLicenseException());
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId, OboToken, graphMock.Object, NullLogger.Instance);
+
+        result.Should().BeNull();
+        errorCode.Should().Be("TEAMS_LICENSE_REQUIRED");
+
+        var dbSession = await _db.Sessions.FindAsync(session.SessionId);
+        dbSession!.Status.Should().Be(SessionStatus.Draft);
+    }
+
+    // ─── Graph failure → rollback ───────────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_GraphFailure_ReturnsPublishFailed_RollsBackWebinar()
+    {
+        var (_, session) = await SeedPublishedSeriesWithDraftSessionAsync();
+
+        var graphMock = new Mock<ITeamsGraphClient>();
+        graphMock.Setup(g => g.CreateWebinarAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), OboToken, default))
+            .ReturnsAsync("webinar-to-rollback");
+        graphMock.Setup(g => g.PublishWebinarAsync("webinar-to-rollback", OboToken, default))
+            .ThrowsAsync(new InvalidOperationException("Graph publish failed"));
+        graphMock.Setup(g => g.DeleteWebinarAsync("webinar-to-rollback", OboToken, default))
+            .Returns(Task.CompletedTask);
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId, OboToken, graphMock.Object, NullLogger.Instance);
+
+        result.Should().BeNull();
+        errorCode.Should().Be("SESSION_PUBLISH_FAILED");
+
+        var dbSession = await _db.Sessions.FindAsync(session.SessionId);
+        dbSession!.Status.Should().Be(SessionStatus.Draft);
+        dbSession.TeamsWebinarId.Should().BeNull();
+
+        graphMock.Verify(g => g.DeleteWebinarAsync("webinar-to-rollback", OboToken, default), Times.Once);
+    }
+
+    // ─── Null graph client → stub path ──────────────────────────────────────
+
+    [Fact]
+    public async Task PublishAsync_NullGraphClient_SetsPublishedWithoutTeams()
+    {
+        var (_, session) = await SeedPublishedSeriesWithDraftSessionAsync();
+
+        var (result, errorCode) = await _sut.PublishAsync(
+            session.SessionId, OwnerUserId);
+
+        errorCode.Should().BeNull();
+        result.Should().NotBeNull();
+        result!.Status.Should().Be("Published");
+        result.TeamsWebinarId.Should().BeNull();
+
+        var dbSession = await _db.Sessions.FindAsync(session.SessionId);
+        dbSession!.Status.Should().Be(SessionStatus.Published);
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────────
+
+    private async Task<(EdgeFront.Builder.Domain.Entities.Series, Session)> SeedPublishedSeriesWithDraftSessionAsync()
+    {
+        var series = new EdgeFront.Builder.Domain.Entities.Series
+        {
+            SeriesId = Guid.NewGuid(),
+            OwnerUserId = OwnerUserId,
+            Title = "Published Series",
+            Status = SeriesStatus.Published,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _db.Series.Add(series);
+
+        var session = BuildDraftSession(series.SeriesId);
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+        return (series, session);
+    }
+
+    private static Session BuildDraftSession(Guid seriesId) => new()
+    {
+        SessionId = Guid.NewGuid(),
+        SeriesId = seriesId,
+        OwnerUserId = OwnerUserId,
+        Title = "New Draft Session",
+        StartsAt = DateTime.UtcNow.AddDays(7),
+        EndsAt = DateTime.UtcNow.AddDays(7).AddHours(1),
+        Status = SessionStatus.Draft
+    };
+}


### PR DESCRIPTION
This pull request adds support for publishing individual draft sessions within a published series, introduces tracking for draft session counts, and updates both backend and frontend to handle these new capabilities. The changes include new API endpoints, DTO updates, backend logic for session publishing, and UI improvements for session and series management.