### PR TITLE
Align instruction ecosystem with actual codebase and remove spec references

### DIFF
--- a/.github/agents/aspnet-api-expert.agent.md
+++ b/.github/agents/aspnet-api-expert.agent.md
@@ -17,10 +17,8 @@ Your job is to implement and review ASP.NET Core minimal APIs while orchestratin
 - Use async and cancellation tokens for I/O paths.
 - Use configuration providers for settings and secrets; never commit local overrides with secrets.
 
-## Spec Authority
-- Read relevant specs in `docs/specs/` before implementing: SPEC-010, SPEC-110, SPEC-120, SPEC-300.
-- Implementation scope must not exceed the referenced spec's scope.
-- If a required rule is missing or ambiguous, add `TODO-SPEC` and stop — do not invent behavior.
+## Guardrails (Requirements)
+- If requirements are unclear or missing, ask the user for clarification — do not invent behavior.
 
 ## Guardrails
 - Do not expose domain entities directly as API contracts.
@@ -41,7 +39,7 @@ Your job is to implement and review ASP.NET Core minimal APIs while orchestratin
 - If work spans multiple concerns, invoke relevant skills in sequence and keep this agent focused on orchestration and final synthesis.
 
 ## Working Method
-1. Discovery first: inspect `readme.md`, `docs/`, and backend project files before editing.
+1. Discovery first: inspect `readme.md` and backend project files before editing.
 2. Classify the task stage and route to the relevant skill(s) before implementation details.
 3. Keep endpoints thin: place business logic in feature/domain/application components, not inline in endpoint delegates.
 4. Validate changes: run the narrowest useful `dotnet` build/test command available for touched backend code.

--- a/.github/agents/graph-teams-integration.agent.md
+++ b/.github/agents/graph-teams-integration.agent.md
@@ -5,7 +5,7 @@ description: Used for Microsoft Graph and Teams integration work in src/backend;
 
 You are the Microsoft Graph and Teams integration expert for `src/backend`.
 
-Your job is to implement and review all Teams webinar integration logic per SPEC-200 and related specs.
+Your job is to implement and review all Teams webinar integration logic.
 
 ## Primary Responsibilities
 - Implement and maintain the delegated-only Graph permission model (OBO flow for all operations).
@@ -13,13 +13,9 @@ Your job is to implement and review all Teams webinar integration logic per SPEC
 - Build the user-initiated data sync pipeline: fetch registrations/attendance via OBO, normalize, upsert, trigger metrics recompute.
 - Implement drift detection with 5-minute caching per session.
 
-## Spec Authority
-- SPEC-200 defines integration flows, lifecycle, and the delegated-only permission model.
-- SPEC-210 is **deprecated** — webhooks have been removed in favor of user-initiated delegated sync.
-- SPEC-010 defines domain normalization (eTLD+1), identity rules, and acceptance tests.
-- SPEC-300 defines metrics recompute triggers and transaction boundaries.
-- SPEC-120 defines database schema.
-- If a required rule is missing, add `TODO-SPEC` and stop.
+## Guardrails (Requirements)
+- If requirements are unclear or missing, ask the user for clarification — do not invent behavior.
+- Webhooks have been removed in favor of user-initiated delegated sync.
 
 ## Graph API Knowledge
 - Create/Update/Delete webinars: `POST/PATCH/DELETE /solutions/virtualEvents/webinars` — delegated only (`VirtualEvent.ReadWrite`).
@@ -34,8 +30,8 @@ Your job is to implement and review all Teams webinar integration logic per SPEC
 
 ## Guardrails
 - Never store raw Graph API tokens in the database.
-- Never use application permissions — the architecture is delegated-only per SPEC-200.
-- Data sync must be idempotent per SPEC-200.
+- Never use application permissions — the architecture is delegated-only.
+- Data sync must be idempotent.
 - Publish must be atomic with compensating rollback on failure.
 - If compensating rollback fails: log, surface partial-failure state, do not crash.
 - Do not modify `src/frontend` unless the task explicitly requires coordinated changes.
@@ -48,12 +44,12 @@ Your job is to implement and review all Teams webinar integration logic per SPEC
 - Use `api-test-strategy` for integration test design.
 
 ## Working Method
-1. Read the relevant SPEC before any implementation.
+1. Review the domain rules and existing implementation before any changes.
 2. All Graph operations use OBO flow — confirm user authentication is present.
 3. Route to relevant skills for detailed workflow guidance.
-4. Implement with idempotency and error handling per spec.
+4. Implement with idempotency and error handling.
 5. Validate with `dotnet build` and run targeted tests.
-6. Report changed files, Graph API calls made, and any spec gaps found.
+6. Report changed files, Graph API calls made, and any open questions found.
 
 ## Output Expectations
 - Return concise implementation summaries with Graph API endpoints used.

--- a/.github/agents/tdd-engineer.agent.md
+++ b/.github/agents/tdd-engineer.agent.md
@@ -15,10 +15,9 @@ You are the TDD specialist for this repository.
 - Backend (`src/backend`): keep endpoint coverage focused on behavior and contract outcomes.
 - Discover and use existing test/build scripts from manifests before introducing any new tooling.
 
-## Spec Authority
-- Spec acceptance tests (SPEC-010 §3, SPEC-300 §7/§8) define mandatory test cases.
-- Read the relevant spec's Definition of Done before designing test coverage.
-- If a required test scenario is ambiguous, add `TODO-SPEC` and stop.
+## Guardrails (Requirements)
+- Domain computation logic (normalization, metrics, warm rules) has mandatory unit test cases defined in the `domain-metrics-computation` skill.
+- If a required test scenario is ambiguous, ask the user for clarification — do not invent behavior.
 
 ## Guardrails
 - Do not skip tests when behavior changes.

--- a/.github/agents/ui-ux-nextjs.agent.md
+++ b/.github/agents/ui-ux-nextjs.agent.md
@@ -15,11 +15,9 @@ You are the UI/UX expert for `src/frontend`.
 - Use existing Tailwind utility-first styling patterns already present in the codebase.
 - Ensure async experiences include clear loading and error handling states.
 
-## Spec Authority
-- Read SPEC-100 in `docs/specs/` before implementing any screen or UX flow.
-- SPEC-100 defines field lists, empty states, delete confirmations, auth flow, and error states.
-- SPEC-110 defines API response DTOs the frontend must consume.
-- If a required UX rule is missing, add `TODO-SPEC` and stop — do not invent behavior.
+## Guardrails (Requirements)
+- Review existing screens and UI patterns before implementing any new screen or UX flow.
+- If a required UX rule is unclear or missing, ask the user for clarification — do not invent behavior.
 
 ## Guardrails
 - Do not introduce new UI frameworks without explicit request.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,10 @@
 # Project Guidelines
 
-## Spec-Driven Development
-- Authoritative specifications live in `docs/specs/edge_front_builder_master_spec_index.md` and individual `docs/specs/spec_*.md` files.
-- Non-authoritative docs (playbooks, planning docs) may guide process but cannot override SPEC behavior.
-- Every implementation task must reference the SPEC ID being implemented.
-- Implementation scope must not exceed the spec's defined scope.
-- If conflict exists between specs, precedence follows dependency order (SPEC-000 > SPEC-010 > downstream).
-- If a required rule is missing or ambiguous in a spec, add `TODO-SPEC` and stop — do not invent behavior.
+## Development Workflow
+- Development uses **plan-mode interactive workflow** — requirements are discussed and implemented interactively.
+- If requirements are unclear or missing, ask the user for clarification before inventing behavior.
+- Use custom agents and skills for specialized domain guidance (testing, observability, Graph integration, etc.).
+- Keep implementation scope focused on the current task.
 
 ## Code Style
 - Keep changes minimal and scoped to the task.
@@ -14,12 +12,12 @@
 - Place implementation code under `src/` and tests under `tests/` unless the task explicitly requires otherwise.
 
 ## Architecture
-- `src/frontend/` — Next.js 16 App Router (React 19, TypeScript, Tailwind CSS)
+- `src/frontend/` — Next.js 16 App Router (React 19, TypeScript, Tailwind CSS v4, Primer React v38)
 - `src/backend/` — ASP.NET Core minimal API (.NET 10, EF Core, Azure SQL)
-- Frontend authenticates users via Entra ID (MSAL.js / next-auth).
+- Frontend authenticates users via Entra ID (next-auth).
 - Backend validates JWT access tokens on all user/business endpoints.
 - Data sync is user-initiated via delegated token on page load (no webhooks or background services).
-- Microsoft Graph uses delegated-only permission model per SPEC-200:
+- Microsoft Graph uses delegated-only permission model:
   - All Graph operations use OBO flow — user must be present
   - No application permissions required
 - Treat frontend and backend as separate components; avoid coupling unless a task explicitly introduces shared contracts.
@@ -28,11 +26,25 @@
 ## Build and Test
 - Backend: `dotnet build` and `dotnet test` from `src/backend`
 - Frontend: `npm run lint` and `npm run build` from `src/frontend`
+- Frontend E2E: `npx playwright test` from `src/frontend`
 - Before running commands, verify scripts exist in the relevant manifest (`package.json`, `.csproj`).
-- All specs require comprehensive unit and integration tests per their Definition of Done.
 
 ## Conventions
-- Use a discovery-first workflow for each task: check `docs/specs/`, `readme.md`, and local manifests before implementing.
+- Use a discovery-first workflow for each task: check `readme.md` and local manifests before implementing.
 - Prefer small, reversible edits and document assumptions when repository conventions are not yet established.
 - Do not introduce new frameworks, tooling, or directory structure unless requested.
 - Save architecture docs, FAQs, and session research/outcome writeups only in `docs/` using clear kebab-case names.
+
+## Instruction Ecosystem Congruency
+After implementing code changes, verify that instruction files, agents, and skills remain accurate:
+
+1. **Technology references** — Do framework names, library names, and version numbers in instruction files still match `package.json` and `.csproj` dependencies?
+2. **Project structure** — Do directory paths and file organization descriptions still match the actual layout?
+3. **Build and test commands** — Do referenced commands still exist in the relevant manifests?
+4. **Agent skill routing** — Do agent files reference skills that still exist and are named correctly?
+5. **Domain rules in skills** — If domain logic changed (schema, computation rules, Graph flows), are the corresponding skills updated?
+6. **Instruction file pointers** — Do "Agent Routing" sections in instruction files still point to the correct agents?
+
+This check applies to all files in `.github/copilot-instructions.md`, `.github/instructions/`, `.github/agents/`, and `.github/skills/`.
+
+Run this check after any code change that adds/removes/renames dependencies, changes project structure, modifies build/test scripts, or alters domain rules. If any file is now inaccurate, update it as part of the same change.

--- a/.github/instructions/aspnet-webapi.instructions.md
+++ b/.github/instructions/aspnet-webapi.instructions.md
@@ -8,17 +8,16 @@ applyTo: "src/backend/**"
 These instructions apply to the backend project under `src/backend`.
 
 ## Instruction Consistency
-- After making backend changes, review this file and update it if guidance is no longer accurate.
-- Keep the instruction set aligned with the current architecture and dependencies.
+- After making backend changes, review this file and any agents/skills that reference the backend stack to ensure they still match the code.
+- See the "Instruction Ecosystem Congruency" section in `copilot-instructions.md` for the full checklist.
 
-## Spec Authority
-- All implementation must reference and conform to the authoritative specs in `docs/specs/`.
-- SPEC-010 defines domain model, identity rules, and computation logic.
-- SPEC-110 defines API surface, endpoints, and DTO contracts.
-- SPEC-120 defines database schema, column types, constraints, and indexes.
-- SPEC-200 defines Teams/Graph integration, delegated data sync, and drift detection.
-- SPEC-300 defines metrics engine computation and transaction boundaries.
-- If a required rule is missing in a spec, add `TODO-SPEC` comment and stop.
+## Agent Routing
+- Testing (TDD, test strategy) → `tdd-engineer` agent
+- Logging and observability → `observability-sre` agent
+- Graph/Teams integration → `graph-teams-integration` agent
+- Schema and migrations → use `data-schema-migration` skill via `aspnet-api-expert`
+- API contract design → use `api-contract-design` skill via `aspnet-api-expert`
+- If requirements are unclear or missing, ask the user for clarification before inventing behavior.
 
 ## Architecture
 - Use a minimal API style unless the feature requires controllers.
@@ -32,7 +31,7 @@ These instructions apply to the backend project under `src/backend`.
 - `Domain/` for core entities, value objects, domain rules (identity, normalization, warm/influence logic).
 - `Infrastructure/` for data access, external integrations, providers.
 - `Infrastructure/Graph/` for TeamsGraphClient, OBO token service.
-- `Metrics/` for recompute orchestrator per SPEC-300.
+- `Metrics/` for recompute orchestrator.
 - `Common/` for shared primitives, errors, and result types.
 - Tests live in `tests/backend/` mirroring feature folders.
 
@@ -40,35 +39,28 @@ These instructions apply to the backend project under `src/backend`.
 - Target framework: .NET 10 (`net10.0`).
 - Use built-in DI, configuration, and logging.
 - Prefer `Microsoft.Extensions.*` abstractions over concrete libs.
-- EF Core with explicit migrations per SPEC-120.
+- EF Core with explicit migrations.
 - Microsoft.Identity.Web for Entra ID JWT validation and OBO token acquisition.
 - Microsoft.Graph SDK for Teams webinar operations.
 
 ## API Design
-- Base path: `/api/v1` per SPEC-110.
-- Use resource-oriented routes per SPEC-110 endpoint definitions.
-- Use proper HTTP verbs and status codes per SPEC-110 DTO contracts.
-- Validate inputs and return problem details (SPEC-110 error envelope).
+- Base path: `/api/v1`.
+- Use resource-oriented routes.
+- Use proper HTTP verbs and status codes.
+- Validate inputs and return problem details.
 - Use DTOs for request/response; never expose domain entities directly.
 - Prefer async APIs and cancellation tokens for I/O.
 - No pagination in V1 — list endpoints return all results for authenticated user.
 
 ## Microsoft Graph Integration
-- Delegated-only permission model per SPEC-200:
-  - All Graph operations use OBO flow — `VirtualEvent.ReadWrite` (delegated)
-  - No application permissions required
-- Centralized token acquisition service (TeamsGraphClient).
-- OBO tokens used for all Graph operations — user must be authenticated.
-- Data sync (registrations, attendance) triggered on page load via delegated token.
+- Delegated-only permission model — all Graph operations use OBO flow.
+- For detailed Graph integration guidance, use the `graph-teams-integration` agent.
 
 ## Data Schema
-- Follow SPEC-120 for all table definitions, column types, constraints, indexes.
-- UUID primary keys, UTC datetime2, EF Core migrations only.
-- JSON columns (nvarchar(max)) for warm account lists per SPEC-120/SPEC-300.
-- Session.status: Draft | Published (not Reconciled).
-- Session.reconcileStatus: Synced | Reconciling.
-- Domain normalization: eTLD+1 / public-suffix-aware registrable domain parsing per SPEC-010.
-- Internal domain exclusion list: sourced from validated environment/config setting.
+- UUID primary keys generated client-side.
+- All datetime columns are datetime2 stored in UTC.
+- EF Core with explicit migrations only — no auto-migration.
+- For detailed schema definitions, constraints, and indexes, use the `data-schema-migration` skill.
 
 ## Security and Configuration
 - Keep secrets in user secrets or environment variables.
@@ -76,18 +68,10 @@ These instructions apply to the backend project under `src/backend`.
 - Validate configuration with options binding and `ValidateOnStart`.
 - Required config: Entra client id/tenant id/secret, DB connection string, internal domain list.
 
-## Error Handling and Logging
+## Error Handling
 - Centralize error handling via middleware or minimal API filters.
-- Log with structured logging and correlation IDs for key operations per SPEC-000.
 - Do not log secrets or PII.
-- Teams licensing errors: surface clear "webinar license required" message, do not retry.
-
-## Test-Driven Development (TDD)
-- Write tests first: red -> green -> refactor.
-- Prefer xUnit and fluent assertions for readability.
-- Spec acceptance tests (SPEC-010 §3, SPEC-300 §7/§8) must be implemented as unit + integration tests.
-- Mock external systems (Graph API); avoid mocking internal logic.
-- Metrics engine: 100% unit coverage for computation rules.
+- For detailed logging policy and observability guidance, use the `observability-sre` agent.
 
 ## Best Practices
 - Keep methods small and single-purpose.

--- a/.github/instructions/nextjs.instructions.md
+++ b/.github/instructions/nextjs.instructions.md
@@ -8,14 +8,14 @@ applyTo: "src/frontend/**"
 These instructions apply to the frontend project under `src/frontend`.
 
 ## Instruction Consistency
-- After making frontend changes, review this file and update it if guidance is no longer accurate.
-- Keep the instruction set aligned with the current architecture and dependencies.
+- After making frontend changes, review this file and any agents/skills that reference the frontend stack to ensure they still match the code.
+- See the "Instruction Ecosystem Congruency" section in `copilot-instructions.md` for the full checklist.
 
-## Spec Authority
-- All implementation must reference and conform to the authoritative specs in `docs/specs/`.
-- SPEC-100 defines screens, field lists, UX contracts, loading/error states, and auth flow.
-- SPEC-110 defines API endpoints and response DTOs the frontend consumes.
-- If a required UX rule is missing in a spec, add `TODO-SPEC` comment and stop.
+## Agent Routing
+- Testing (TDD, test strategy) → `tdd-engineer` agent
+- UX design and composition → `ui-ux-nextjs` agent
+- Accessibility checks → use `frontend-accessibility-and-ux-acceptance` skill via `ui-ux-nextjs`
+- If requirements are unclear or missing, ask the user for clarification before inventing behavior.
 
 ## Architecture
 - Use the App Router (`app/`) with React Server Components by default.
@@ -29,19 +29,21 @@ These instructions apply to the frontend project under `src/frontend`.
 - `app/sessions/` for session detail, edit flows.
 - `components/` for reusable UI; keep them pure and prop-driven.
 - `lib/` for data access, API clients, and helpers.
-- `lib/api/` for typed API client helpers consuming SPEC-110 DTOs.
+- `lib/api/` for typed API client helpers consuming backend API DTOs.
 - `public/` for static assets.
 - E2E tests live in `src/frontend/e2e/`.
 
 ## Core Dependencies
 - Next.js 16 with React 19.
 - TypeScript is required for all new files.
-- Tailwind CSS is available; prefer utility-first styling.
+- Tailwind CSS v4 is available; prefer utility-first styling.
+- Primer React v38 (@primer/react) with @primer/octicons-react for UI components.
 - ESLint must remain clean; use `npm run lint`.
-- MSAL.js or next-auth for Entra ID authentication.
+- next-auth for Entra ID authentication.
+- Playwright for E2E testing (configured in `playwright.config.ts`).
 
 ## Authentication
-- Login via Entra ID redirect per SPEC-100.
+- Login via Entra ID redirect.
 - Unauthenticated access → redirect to Entra login.
 - Token refresh handled silently; on failure → redirect to login.
 - Logout clears session and redirects to login.
@@ -55,18 +57,6 @@ These instructions apply to the frontend project under `src/frontend`.
 - Metrics are read-only from API (no compute-on-read).
 - No pagination in V1 — list endpoints return all results.
 
-## Screens and UX Contracts (per SPEC-100)
-- Series List: title, status, session count, metrics summary.
-- Series Detail: header with SeriesMetrics, sessions table with per-session metrics/status and "Last Synced" column.
-- Session Create/Edit (Draft): title, startsAt, endsAt fields; save locally only.
-- Session Edit (Published): "Save & Publish to Teams" atomic action.
-- Publish Series: confirmation dialog, progress indicator, failure with retry.
-- Drift: badges and comparison values per SPEC-100 display rules.
-- Data Sync: auto-sync on page load for published sessions; "Syncing from Teams…" indicator; "Last Synced" timestamps.
-- Delete: confirmation dialogs for both session and series deletion.
-- Teams licensing error: "webinar license required" message, no retry.
-- Empty states: defined per screen in SPEC-100.
-
 ## UI and UX
 - Favor accessible, semantic HTML.
 - Use loading and error boundaries for routes.
@@ -75,15 +65,9 @@ These instructions apply to the frontend project under `src/frontend`.
 - Inline error banners with retry for failed API calls.
 - No optimistic updates in V1 (wait for server confirmation).
 
-## Test-Driven Development (TDD)
-- Write tests first: red -> green -> refactor.
-- Use React Testing Library and Jest or Vitest as configured.
-- Test user-visible behavior, not implementation details.
-- Add integration tests for critical flows: publish, atomic edit, delete.
-
 ## Best Practices
 - Keep components small and focused.
-- Avoid `any`; use accurate types and shared interfaces matching SPEC-110 DTOs.
+- Avoid `any`; use accurate types and shared interfaces matching backend API DTOs.
 - Use `async` server actions where appropriate.
 - Prefer composition over prop drilling.
 

--- a/.github/skills/data-schema-migration/skill.md
+++ b/.github/skills/data-schema-migration/skill.md
@@ -1,6 +1,6 @@
 ---
 name: data-schema-migration
-description: 'Design and implement EF Core database schema, migrations, and constraint validation per SPEC-120.'
+description: 'Design and implement EF Core database schema, migrations, and constraint validation.'
 argument-hint: 'Describe the table, column, constraint, or migration change needed.'
 ---
 
@@ -10,16 +10,16 @@ argument-hint: 'Describe the table, column, constraint, or migration change need
 - Creating or modifying EF Core entity configurations
 - Adding or updating database migrations
 - Implementing unique constraints, indexes, or FK cascades
-- Validating schema alignment with SPEC-120
+- Validating schema alignment with project domain model
 
 ## Quick Checklist
-1. Verify all columns match SPEC-120 type definitions.
-2. Verify all unique constraints and FK cascades per SPEC-120.
-3. Verify all indexes per SPEC-120.
+1. Verify all columns match schema reference type definitions.
+2. Verify all unique constraints and FK cascades per schema reference below.
+3. Verify all indexes per schema reference below.
 4. Generate migration via `dotnet ef migrations add`.
 5. Validate migration applies cleanly.
 
-## Schema Reference (SPEC-120)
+## Schema Reference
 ### Series
 - seriesId (UUID, PK), ownerUserId (string), title (string), status (string: Draft|Published), createdAt (datetime2 UTC), updatedAt (datetime2 UTC)
 - Unique: (ownerUserId, title)
@@ -55,13 +55,13 @@ argument-hint: 'Describe the table, column, constraint, or migration change need
 - NormalizedAttendance(sessionId, emailDomain)
 
 ## Decision Points
-- If a column type in code doesn't match SPEC-120: fix the code, not the spec.
-- If a new column is needed that isn't in SPEC-120: add `TODO-SPEC` and request spec update.
+- If a column type in code doesn't match the schema reference below, ask the user which is correct.
+- If a new column is needed that isn't in the schema reference, ask the user for the column definition.
 - If migration conflicts arise: resolve by rebasing, not by editing existing migrations.
 
 ## Completion Checks
-- All entity configurations match SPEC-120 column definitions exactly.
+- All entity configurations match schema reference column definitions exactly.
 - All unique constraints are enforced and validated via integration tests.
-- All indexes are created per SPEC-120.
+- All indexes are created per schema reference.
 - Migration applies cleanly to empty database.
 - JSON value converters work correctly for warm account lists.

--- a/.github/skills/delegated-data-sync-pipeline/skill.md
+++ b/.github/skills/delegated-data-sync-pipeline/skill.md
@@ -1,6 +1,6 @@
 ---
 name: delegated-data-sync-pipeline
-description: 'Implement the delegated data sync pipeline: fetch from Graph, normalize, deduplicate, upsert, and trigger metrics recompute per SPEC-200/300.'
+description: 'Implement the delegated data sync pipeline: fetch from Graph, normalize, deduplicate, upsert, and trigger metrics recompute.'
 argument-hint: 'Describe the sync step, normalization behavior, or idempotency concern to implement.'
 ---
 
@@ -16,11 +16,11 @@ argument-hint: 'Describe the sync step, normalization behavior, or idempotency c
 1. User opens session/series detail page → triggers sync via OBO token.
 2. Fetch registrations and attendance from Graph API (delegated).
 3. Normalize + upsert into NormalizedRegistration or NormalizedAttendance.
-4. Trigger atomic metrics recompute per SPEC-300.
+4. Trigger atomic metrics recompute.
 5. Update `LastSyncAt` timestamp on session.
 6. Verify idempotency — repeated syncs must not inflate metrics.
 
-## Session Sync Flow (SPEC-200)
+## Session Sync Flow
 1. Receive sync request with user's OBO token.
 2. Fetch registrations from Graph: `GET /solutions/virtualEvents/webinars/{id}/registrations`.
 3. Fetch attendance from Graph via sessions → attendanceReports → attendanceRecords.
@@ -31,7 +31,7 @@ argument-hint: 'Describe the sync step, normalization behavior, or idempotency c
 8. Update `LastSyncAt` timestamp on session.
 9. Commit atomically.
 
-## Series Sync Flow (SPEC-200)
+## Series Sync Flow
 1. Iterate all published sessions in the series.
 2. Sync each session individually.
 3. Individual session failures are logged but do not block other sessions.
@@ -52,7 +52,7 @@ argument-hint: 'Describe the sync step, normalization behavior, or idempotency c
 - If Graph data fetch fails: surface error, do not partially commit.
 - If concurrent syncs arrive for same session: DB transaction isolation prevents race conditions.
 
-## Mandatory Integration Tests (SPEC-200, SPEC-300 §8)
+## Mandatory Integration Tests
 - Sync → normalized upsert → metrics updated
 - Repeated sync does not inflate metrics
 - Concurrent syncs for same session → no inconsistent metrics

--- a/.github/skills/domain-metrics-computation/skill.md
+++ b/.github/skills/domain-metrics-computation/skill.md
@@ -1,6 +1,6 @@
 ---
 name: domain-metrics-computation
-description: 'Implement domain normalization (eTLD+1), identity rules, W1/W2 warm logic, influence counting, and internal domain exclusion per SPEC-010 and SPEC-300.'
+description: 'Implement domain normalization (eTLD+1), identity rules, W1/W2 warm logic, influence counting, and internal domain exclusion.'
 argument-hint: 'Describe the domain rule, metric computation, or normalization behavior to implement or test.'
 ---
 
@@ -17,10 +17,10 @@ argument-hint: 'Describe the domain rule, metric computation, or normalization b
 ## Quick Checklist
 1. Apply normalization: trim + lowercase email, eTLD+1 for domain.
 2. Filter internal domains before computing influence and warm.
-3. Follow SPEC-300 computation pseudocode exactly.
+3. Follow computation pseudocode below exactly.
 4. Verify warm precedence: W2 > W1, one entry per domain.
 
-## Domain Normalization (SPEC-010)
+## Domain Normalization
 1. Email: trim whitespace + lowercase. Identity key = normalized email.
 2. Domain: extract registrable domain using public-suffix-aware eTLD+1 parsing.
    - `kt.kpmg.com` → `kpmg.com`
@@ -29,7 +29,7 @@ argument-hint: 'Describe the domain rule, metric computation, or normalization b
 3. Internal domain list: loaded from environment/config, validated at startup.
 4. Normalization applied before persistence — store only normalized values.
 
-## SessionMetrics Computation (SPEC-300 §3.1)
+## SessionMetrics Computation
 All counts exclude internal domains for influence/warm, include for totals:
 1. `totalRegistrations` = COUNT(NormalizedRegistration) — all domains
 2. `totalAttendees` = COUNT(NormalizedAttendance) — all domains
@@ -37,7 +37,7 @@ All counts exclude internal domains for influence/warm, include for totals:
 4. `uniqueAttendeeAccountDomains` = COUNT(DISTINCT emailDomain) from attendance — external only
 5. `warmAccountsTriggered` (W1): for each external emailDomain in attendance, if COUNT(DISTINCT email) >= 2 → include. Lexicographic sort.
 
-## SeriesMetrics Computation (SPEC-300 §3.2)
+## SeriesMetrics Computation
 1. `totalRegistrations` = SUM(SessionMetrics.totalRegistrations)
 2. `totalAttendees` = SUM(SessionMetrics.totalAttendees)
 3. `uniqueRegistrantAccountDomains` = COUNT(DISTINCT emailDomain) across all sessions — external only
@@ -48,7 +48,7 @@ All counts exclude internal domains for influence/warm, include for totals:
    - Precedence: W2 > W1 — store one entry per domain
    - Lexicographic sort by accountDomain
 
-## Transaction Boundaries (SPEC-300 §5)
+## Transaction Boundaries
 - Normalized upserts + metrics recompute must be atomic (single DB transaction).
 - Concurrency: use database-level strategy to prevent race conditions on same session.
 - If any step fails: rollback entire transaction; caller handles retry.
@@ -59,7 +59,7 @@ All counts exclude internal domains for influence/warm, include for totals:
 - W1 does not trigger on duplicate records of same email (must be distinct emails).
 - If eTLD+1 library is unavailable, use a well-known public suffix list; do not fall back to last-2-label.
 
-## Mandatory Unit Tests (SPEC-300 §7)
+## Mandatory Unit Tests
 - Same email differing by case → one Person
 - Subdomain stripped correctly via eTLD+1
 - Different TLDs = different accounts
@@ -76,5 +76,5 @@ All counts exclude internal domains for influence/warm, include for totals:
 ## Completion Checks
 - All normalization uses eTLD+1 (no last-2-label heuristic).
 - Internal domain filter applied before influence/warm computation.
-- All SPEC-300 §7 unit tests pass.
+- All mandatory unit tests pass.
 - Metrics recompute is atomic with normalized data writes.

--- a/.github/skills/graph-teams-integration/skill.md
+++ b/.github/skills/graph-teams-integration/skill.md
@@ -1,7 +1,7 @@
 ---
 name: graph-teams-integration
 description: 'Design and implement Microsoft Graph Virtual Events integration with delegated-only OBO token flow, webinar lifecycle, and user-initiated data sync.'
-argument-hint: 'Describe the Graph operation, token flow context, and target SPEC section.'
+argument-hint: 'Describe the Graph operation and token flow context.'
 ---
 
 # Graph Teams Integration
@@ -27,7 +27,7 @@ argument-hint: 'Describe the Graph operation, token flow context, and target SPE
    - Drift detection → OBO flow (delegated)
 2. Implement token acquisition:
    - OBO: Extract user JWT from request → call `ITokenAcquisition.GetAccessTokenForUserAsync` with Graph scopes
-   - **No client credentials** — all operations require an authenticated user per SPEC-200
+   - **No client credentials** — all operations require an authenticated user
 3. Implement the Graph API call with retry and error classification:
    - 401/403: Token or permission issue — log and surface clearly
    - 404: Resource not found — handle gracefully for drift/delete
@@ -36,7 +36,7 @@ argument-hint: 'Describe the Graph operation, token flow context, and target SPE
 4. Map Graph response to domain model (e.g., webinar ID → teamsWebinarId).
 5. Log all Graph operations with correlation ID, operation name, and result.
 
-## Publish Flow (SPEC-200)
+## Publish Flow
 1. For each session in series:
    a. Create webinar via OBO → store teamsWebinarId
    b. Publish webinar via OBO → POST .../publish
@@ -45,7 +45,7 @@ argument-hint: 'Describe the Graph operation, token flow context, and target SPE
    b. If rollback fails: log failures, surface partial-failure state
    c. Return failure to caller
 
-## Data Sync Flow (SPEC-200)
+## Data Sync Flow
 1. User opens session/series page → triggers sync.
 2. Fetch registrations via OBO: `GET /solutions/virtualEvents/webinars/{id}/registrations`.
 3. Fetch attendance via OBO: sessions → attendanceReports → attendanceRecords.

--- a/readme.md
+++ b/readme.md
@@ -58,10 +58,10 @@ EdgeFront Builder is a **webinar management platform** that integrates with Micr
 
 | Layer | Technology |
 |---|---|
-| Frontend | Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS v4, shadcn/ui |
+| Frontend | Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS v4, Primer React v38 |
 | Backend | ASP.NET Core Minimal API, .NET 10, EF Core |
 | Database | Azure SQL |
-| Auth | Microsoft Entra ID (MSAL / next-auth, single-tenant) |
+| Auth | Microsoft Entra ID (next-auth, single-tenant) |
 | Graph integration | Microsoft Graph v1 — delegated `VirtualEvent.ReadWrite` via OBO flow |
 | Hosting | Azure App Service |
 
@@ -70,7 +70,7 @@ EdgeFront Builder is a **webinar management platform** that integrates with Micr
 ## Project Structure
 
 ```text
-docs/           # Specs, setup guides, screenshots
+docs/           # Setup guides, screenshots
 src/
   backend/      # ASP.NET Core Minimal API
   frontend/     # Next.js App Router app


### PR DESCRIPTION
- Replace spec-driven workflow with plan-mode interactive development
- Add Instruction Ecosystem Congruency check to copilot-instructions.md
- Remove duplicated TDD, logging, Graph, schema sections from instruction files
- Add Agent Routing sections pointing to specialist agents/skills
- Fix stale tech refs: shadcn/ui→Primer React v38, MSAL→next-auth, Jest→Playwright
- Remove SPEC-XXX labels from 4 agents and 4 skills (domain knowledge preserved)
- Fix README tech stack table

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>