### PR TITLE
Refactor TDD agent instructions and update routing policies across documentation

### DIFF
--- a/.github/agents/edgefront-tdd-engineer.agent.md
+++ b/.github/agents/edgefront-tdd-engineer.agent.md
@@ -1,9 +1,14 @@
 ---
-name: tdd-engineer
+name: edgefront-tdd-engineer
 description: Drives test-first implementation for the Next.js frontend and ASP.NET Core backend.
 ---
 
 You are the TDD specialist for this repository.
+
+## Agent Selection Policy
+- This is the default agent for all TDD and test-first work in this repository.
+- Prefer this agent over generic plugin-provided TDD agents such as `testing-automation:tdd-red`, `testing-automation:tdd-green`, and `testing-automation:tdd-refactor`.
+- Only use generic plugin TDD agents when the user explicitly asks for them by name.
 
 ## Primary Responsibilities
 - Follow red → green → refactor for all feature work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,11 @@
 - Use custom agents and skills for specialized domain guidance (testing, observability, Graph integration, etc.).
 - Keep implementation scope focused on the current task.
 
+## Agent Routing Policy
+- For any TDD, test-first, or regression-test-driven work in this repository, use the `edgefront-tdd-engineer` agent by default.
+- Do not choose generic plugin-provided TDD agents such as `testing-automation:tdd-red`, `testing-automation:tdd-green`, or `testing-automation:tdd-refactor` unless the user explicitly asks for one of them by name.
+- Treat plugin TDD agents as optional supporting tools, not the canonical testing path for this repository.
+
 ## Code Style
 - Keep changes minimal and scoped to the task.
 - Follow existing style in touched files; do not reformat unrelated code.

--- a/.github/instructions/aspnet-webapi.instructions.md
+++ b/.github/instructions/aspnet-webapi.instructions.md
@@ -12,11 +12,12 @@ These instructions apply to the backend project under `src/backend`.
 - See the "Instruction Ecosystem Congruency" section in `copilot-instructions.md` for the full checklist.
 
 ## Agent Routing
-- Testing (TDD, test strategy) → `tdd-engineer` agent
+- Testing (TDD, test strategy) → `edgefront-tdd-engineer` agent
 - Logging and observability → `observability-sre` agent
 - Graph/Teams integration → `graph-teams-integration` agent
 - Schema and migrations → use `data-schema-migration` skill via `aspnet-api-expert`
 - API contract design → use `api-contract-design` skill via `aspnet-api-expert`
+- Do not use generic plugin TDD agents for backend work unless the user explicitly asks for them by name.
 - If requirements are unclear or missing, ask the user for clarification before inventing behavior.
 
 ## Architecture

--- a/.github/instructions/nextjs.instructions.md
+++ b/.github/instructions/nextjs.instructions.md
@@ -12,9 +12,10 @@ These instructions apply to the frontend project under `src/frontend`.
 - See the "Instruction Ecosystem Congruency" section in `copilot-instructions.md` for the full checklist.
 
 ## Agent Routing
-- Testing (TDD, test strategy) → `tdd-engineer` agent
+- Testing (TDD, test strategy) → `edgefront-tdd-engineer` agent
 - UX design and composition → `ui-ux-nextjs` agent
 - Accessibility checks → use `frontend-accessibility-and-ux-acceptance` skill via `ui-ux-nextjs`
+- Do not use generic plugin TDD agents for frontend work unless the user explicitly asks for them by name.
 - If requirements are unclear or missing, ask the user for clarification before inventing behavior.
 
 ## Architecture


### PR DESCRIPTION
This pull request updates the agent routing policy for TDD and test-first work across the repository. The main change is to designate `edgefront-tdd-engineer` as the default and canonical agent for all TDD and testing-related tasks, replacing the previous `tdd-engineer` agent and explicitly deprioritizing generic plugin TDD agents. These updates ensure consistency in agent selection for both frontend and backend projects.