### PR TITLE
Remove Azure DevOps integration section from copilot instructions for clarity and focus on core guidelines.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,18 +14,6 @@
 - For general board CRUD, sprint planning, task/bug management, use the `devops-workitem-manager` agent.
 - If work items are part of the spec-driven hierarchy - especially those in `New`/`Active` or tagged `review:ready` / `techspec:stale` - prefer `spec-driven-development` for edits to Description or Acceptance Criteria.
 
-## Azure DevOps Integration
-- Use the `devops-workitem-manager` agent to read work items from your board, create new items, and update item status.
-- Use the `spec-driven-development` agent to author functional specs as work item hierarchies and generate technical specs as wiki pages.
-- Both agents are pre-configured with organization `kkraus` and project `edgefront-builder` — you never need to specify these.
-- Neither agent is loaded automatically; invoke them explicitly when needed.
-- The `spec-driven-development` agent and `devops-workitem-manager` share awareness of the spec lifecycle via the `spec-lifecycle-management` skill.
-- The spec-driven workflow uses Azure DevOps Agile **State** as the primary lifecycle model and uses only these supplemental query tags: `review:ready` and `techspec:stale`.
-- Section-only spec templates live alongside their owning skills under `.github\skills\*\templates\`; update those files for layout changes, and update agents/skills only for rule, field-mapping, or validation changes.
-- See `docs/spec-driven-development-process.md` for the full spec workflow documentation.
-- Typical spec workflow: User invokes `spec-driven-development` → iterates on functional spec → approves → generates tech spec → implements.
-- Typical board workflow: User invokes `devops-workitem-manager` → reads/creates/updates work items → manages sprints.
-
 ## Code Style
 - Keep changes minimal and scoped to the task.
 - Follow existing style in touched files; do not reformat unrelated code.


### PR DESCRIPTION
This pull request removes the detailed "Azure DevOps Integration" section from the `.github/copilot-instructions.md` file, streamlining the documentation.