### PR TITLE
updates skill names to match folders for Visual Studio compatibility

### DIFF
--- a/.github/skills/api-contract-design/SKILL.md
+++ b/.github/skills/api-contract-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: aspnet-api-contract-design
+name: api-contract-design
 description: 'Design ASP.NET Core minimal API request and response contracts. Use for DTO shapes, route and verb decisions, OpenAPI metadata, and compatibility planning before implementation.'
 argument-hint: 'Describe the endpoint purpose, route and verb, request fields, response variants, and compatibility constraints.'
 ---

--- a/.github/skills/api-test-strategy/SKILL.md
+++ b/.github/skills/api-test-strategy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: aspnet-api-test-strategy
+name: api-test-strategy
 description: 'Define focused tests for ASP.NET Core minimal APIs. Use for endpoint branch coverage, contract assertions, regression planning, and choosing the narrowest useful verification command.'
 argument-hint: 'Describe the endpoint change, risky branches, contract expectations, and desired confidence level.'
 ---

--- a/.github/skills/data-schema-migration/skill.md
+++ b/.github/skills/data-schema-migration/skill.md
@@ -1,5 +1,5 @@
 ---
-name: efcore-schema-and-migrations
+name: data-schema-migration
 description: 'Design EF Core schema changes, constraints, and migrations for the backend data model. Use for entity updates, indexes, uniqueness rules, cascade behavior, and migration planning.'
 argument-hint: 'Describe the entity or table change, columns or constraints affected, and any migration or data-compatibility concerns.'
 ---

--- a/.github/skills/delegated-data-sync-pipeline/skill.md
+++ b/.github/skills/delegated-data-sync-pipeline/skill.md
@@ -1,5 +1,5 @@
 ---
-name: graph-delegated-sync-pipeline
+name: delegated-data-sync-pipeline
 description: 'Design and implement the delegated Graph sync pipeline from fetch through normalization, upsert, and metrics recompute. Use for user-initiated registrations or attendance sync, idempotency, and atomic recomputation.'
 argument-hint: 'Describe the sync stage, Graph data being processed, normalization or deduplication rules, and any idempotency or transaction concern.'
 ---

--- a/.github/skills/deployment-safety-and-rollback/SKILL.md
+++ b/.github/skills/deployment-safety-and-rollback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: release-safety-and-rollback
+name: deployment-safety-and-rollback
 description: 'Define deployment safeguards, environment protections, and rollback readiness for CI/CD releases. Use when adding or reviewing release jobs, promotion controls, or recovery plans.'
 argument-hint: 'Describe the target environment, release strategy, blast-radius concerns, and rollback expectations.'
 ---

--- a/.github/skills/domain-metrics-computation/skill.md
+++ b/.github/skills/domain-metrics-computation/skill.md
@@ -1,5 +1,5 @@
 ---
-name: domain-metrics-and-normalization
+name: domain-metrics-computation
 description: 'Apply email and domain normalization plus session and series metric rules, including W1/W2 warm-account logic and internal-domain exclusion. Use for domain logic changes, recompute behavior, and mandatory unit-test coverage.'
 argument-hint: 'Describe the normalization rule, metric behavior, affected entities or sessions, and whether the task is implementation or test coverage.'
 ---

--- a/.github/skills/frontend-accessibility-and-ux-acceptance/SKILL.md
+++ b/.github/skills/frontend-accessibility-and-ux-acceptance/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: nextjs-accessibility-and-ux-acceptance
+name: frontend-accessibility-and-ux-acceptance
 description: 'Review Next.js interfaces for accessibility and UX acceptance. Use for semantic markup, keyboard flow, responsive behavior, async states, and final user-flow validation before merge.'
 argument-hint: 'Describe the user flow, UI surfaces changed, accessibility risks, and the states that need acceptance coverage.'
 ---

--- a/.github/skills/frontend-test-strategy/SKILL.md
+++ b/.github/skills/frontend-test-strategy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: nextjs-frontend-test-strategy
+name: frontend-test-strategy
 description: 'Define focused frontend tests for Next.js user-visible behavior. Use for rendering, interaction, loading and error states, regression coverage, and choosing narrow verification scope.'
 argument-hint: 'Describe the UI behavior change, affected route or component, risky user-visible states, and the desired confidence level.'
 ---

--- a/.github/skills/github-actions-workflow-composition/SKILL.md
+++ b/.github/skills/github-actions-workflow-composition/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-actions-workflow-design
+name: github-actions-workflow-composition
 description: 'Design GitHub Actions workflows with clear triggers, deterministic job boundaries, safe caching, and diagnosable failure output. Use for new workflows or structural CI/CD refactors.'
 argument-hint: 'Describe the workflow goal, triggers, components involved, job boundaries, and any caching or failure-visibility requirements.'
 ---

--- a/.github/skills/graph-teams-integration/skill.md
+++ b/.github/skills/graph-teams-integration/skill.md
@@ -1,5 +1,5 @@
 ---
-name: graph-teams-webinar-integration
+name: graph-teams-integration
 description: 'Design delegated Microsoft Graph and Teams webinar integration for the backend. Use for OBO token exchange, webinar CRUD, registrations and attendance reads, drift handling, and Graph error semantics.'
 argument-hint: 'Describe the Graph operation, Teams webinar context, delegated scopes or token flow, and any failure or retry concern.'
 ---

--- a/.github/skills/incident-triage-and-diagnostics/SKILL.md
+++ b/.github/skills/incident-triage-and-diagnostics/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reliability-incident-triage
+name: incident-triage-and-diagnostics
 description: 'Triage reliability incidents by isolating likely fault domains and defining safe mitigation and recovery checks. Use during outages, regressions, failed deployments, or recurring degradation.'
 argument-hint: 'Describe the symptoms, timeframe, impacted flows, recent changes, and the logs or telemetry already available.'
 ---

--- a/.github/skills/integration-contract-alignment/SKILL.md
+++ b/.github/skills/integration-contract-alignment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: frontend-backend-contract-alignment
+name: integration-contract-alignment
 description: 'Align frontend consumers with backend API contracts. Use for route or DTO changes, compatibility windows, rollout sequencing, and cross-stack acceptance criteria.'
 argument-hint: 'Describe the backend contract change, affected frontend consumers, rollout constraints, and compatibility expectations.'
 ---

--- a/.github/skills/integration-environment-configuration/SKILL.md
+++ b/.github/skills/integration-environment-configuration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cross-stack-environment-configuration
+name: integration-environment-configuration
 description: 'Validate frontend-backend environment wiring without hardcoded service endpoints. Use for local, dev, and prod config mapping, runtime key alignment, and configuration gap analysis.'
 argument-hint: 'Describe the target environments, required configuration keys, runtime wiring problem, and any suspected naming or source-of-truth gaps.'
 ---

--- a/.github/skills/nextjs-ui-composition-patterns/SKILL.md
+++ b/.github/skills/nextjs-ui-composition-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: nextjs-route-and-component-composition
+name: nextjs-ui-composition-patterns
 description: 'Compose Next.js App Router features with thin routes, reusable components, and intentional server/client boundaries. Use for route refactors, shared UI extraction, or rendering-boundary decisions.'
 argument-hint: 'Describe the route or feature being changed, reusable UI opportunities, async behavior, and any client-only interaction needs.'
 ---

--- a/.github/skills/pipeline-discovery-and-gate-mapping/SKILL.md
+++ b/.github/skills/pipeline-discovery-and-gate-mapping/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci-gate-discovery-and-mapping
+name: pipeline-discovery-and-gate-mapping
 description: 'Inventory existing CI/CD workflows and map required quality gates by component and environment. Use before changing GitHub Actions so pipeline gaps and blockers are explicit.'
 argument-hint: 'Describe the components, environments, and acceptance gates you need inventoried or clarified.'
 ---

--- a/.github/skills/pipeline-validation-and-failure-reporting/SKILL.md
+++ b/.github/skills/pipeline-validation-and-failure-reporting/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci-validation-and-failure-reporting
+name: pipeline-validation-and-failure-reporting
 description: 'Run targeted CI/CD validation and report pass/fail outcomes with clear blockers and rerun scope. Use after workflow changes or when diagnosing failed pipeline runs.'
 argument-hint: 'Describe the workflow changes, gates that need confidence, and whether you are validating pre-merge, pre-release, or an active failure.'
 ---

--- a/.github/skills/status-code-decision-matrix/SKILL.md
+++ b/.github/skills/status-code-decision-matrix/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: http-status-and-payload-semantics
+name: status-code-decision-matrix
 description: 'Choose HTTP status codes and response payload behavior for ASP.NET Core minimal APIs. Use for success and error branch semantics, problem details, conflicts, and compatibility exceptions.'
 argument-hint: 'Describe the operation type, expected success result, known failure modes, and any client-compatibility constraints.'
 ---

--- a/.github/skills/structured-logging-policy/SKILL.md
+++ b/.github/skills/structured-logging-policy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: aspnet-structured-logging-policy
+name: structured-logging-policy
 description: 'Define production-safe structured logging for ASP.NET Core API flows. Use for event naming, stable log fields, correlation context, severity policy, and secret-safe diagnostics.'
 argument-hint: 'Describe the backend flow or endpoint, required operational signals, current logging gaps, and any high-volume or sensitive-data concerns.'
 ---

--- a/.github/skills/tdd-red-green-refactor/SKILL.md
+++ b/.github/skills/tdd-red-green-refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tdd-red-green-refactor-cycle
+name: tdd-red-green-refactor
 description: 'Execute a minimal-scope red-green-refactor workflow. Use for test-first features, regression-first bug fixes, and refactors that must preserve externally observable behavior.'
 argument-hint: 'Describe the requested behavior, target component, test-first constraints, and any limits on refactoring scope.'
 ---

--- a/.github/skills/telemetry-signal-design/SKILL.md
+++ b/.github/skills/telemetry-signal-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: observability-signal-design
+name: telemetry-signal-design
 description: 'Design logs, metrics, and traces for critical frontend and backend flows with clear operator actionability and low noise. Use when adding or revising end-to-end observability.'
 argument-hint: 'Describe the target flow, operational questions to answer, current observability gaps, and any correlation or volume concerns.'
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Thumbs.db
 # editor settings
 .vscode/
 .idea/
+.vs/
 
 # logs
 *.log


### PR DESCRIPTION
This pull request standardizes and clarifies the naming conventions for skill definition files in the `.github/skills` directory. The main change is renaming the `name` fields in each skill's metadata to use more consistent, technology-agnostic, and concise identifiers. This improves discoverability and future maintainability of skill definitions.