### PR TITLE
fix: update branch references from 'main' to 'master' in workflows and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,8 @@ Verify scripts exist in the relevant manifest before running.
 
 ## Security Scanning
 
-`.github/workflows/opengrep.yml` runs OpenGrep (SAST) on every PR to `main`. It is
+`.github/workflows/opengrep.yml` runs OpenGrep (SAST) on every PR to `master` (this
+repo's default branch — there is no `main` branch). It is
 advisory-only (`continue-on-error: true`) — reports to the Security tab but never blocks
 merge. Plain Actions workflow, not a `gh-aw` agentic workflow. Details:
 `docs/opengrep-scanning.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "copilot/**", "spec-*"]
+    branches: [master, "copilot/**", "spec-*"]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   backend:

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -2,7 +2,7 @@ name: OpenGrep Security Scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/docs/opengrep-scanning.md
+++ b/docs/opengrep-scanning.md
@@ -1,8 +1,8 @@
 # OpenGrep Security Scanning
 
 This repo runs [OpenGrep](https://github.com/opengrep/opengrep) — a static application
-security testing (SAST) engine — on every pull request targeting `main`, via
-`.github/workflows/opengrep.yml`.
+security testing (SAST) engine — on every pull request targeting `master` (this repo's
+default branch), via `.github/workflows/opengrep.yml`.
 
 ## Why OpenGrep (not Semgrep)?
 

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ tools/          # PowerShell scripts (e.g., Entra app registration)
 - **Ingestion-ready data model** — normalized registration and attendance records are persisted locally and remain the foundation for follow-on ingestion work.
 - **Metrics persisted on write** — all metric aggregations are computed and stored on write; no compute-on-read.
 - **Delegated-only Graph permissions** — authenticated user context is required for supported directory lookups.
-- **Automated security scanning** — [OpenGrep](https://github.com/opengrep/opengrep) SAST scan runs on every pull request to `main` (advisory-only). See [`docs/opengrep-scanning.md`](docs/opengrep-scanning.md).
+- **Automated security scanning** — [OpenGrep](https://github.com/opengrep/opengrep) SAST scan runs on every pull request to `master` (advisory-only). See [`docs/opengrep-scanning.md`](docs/opengrep-scanning.md).
 
 ---
 


### PR DESCRIPTION
Change all references in workflows and documentation from 'main' to 'master' to align with the repository's default branch.