### PR TITLE
fix: update OpenGrep workflow to include push and schedule triggers for comprehensive security scanning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,8 +44,8 @@ Verify scripts exist in the relevant manifest before running.
 
 ## Security Scanning
 
-`.github/workflows/opengrep.yml` runs OpenGrep (SAST) on every PR to `master` (this
-repo's default branch — there is no `main` branch). It is
+`.github/workflows/opengrep.yml` runs OpenGrep (SAST) on PRs to `master` (this repo's
+default branch — there is no `main` branch), pushes to `master`, and weekly. It is
 advisory-only (`continue-on-error: true`) — reports to the Security tab but never blocks
 merge. Plain Actions workflow, not a `gh-aw` agentic workflow. Details:
 `docs/opengrep-scanning.md`.

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -3,6 +3,12 @@ name: OpenGrep Security Scan
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
+  schedule:
+    # Weekly, off-peak/off-the-hour per GitHub's recommended pattern for
+    # third-party SARIF tools. Mondays 04:23 UTC.
+    - cron: "23 4 * * 1"
 
 permissions:
   contents: read
@@ -10,7 +16,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: opengrep-${{ github.event.pull_request.number }}
+  group: opengrep-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/docs/opengrep-scanning.md
+++ b/docs/opengrep-scanning.md
@@ -1,8 +1,19 @@
 # OpenGrep Security Scanning
 
 This repo runs [OpenGrep](https://github.com/opengrep/opengrep) — a static application
-security testing (SAST) engine — on every pull request targeting `master` (this repo's
-default branch), via `.github/workflows/opengrep.yml`.
+security testing (SAST) engine — via `.github/workflows/opengrep.yml`, triggered on:
+
+- **`pull_request`** to `master` (this repo's default branch) — results attach to the PR.
+- **`push`** to `master` — establishes the baseline analysis on the default branch.
+- **`schedule`** — weekly (Mondays 04:23 UTC), to catch drift from upstream rule updates.
+
+> **Why push and schedule, not just pull_request?** A `pull_request`-triggered SARIF
+> upload attaches results to that PR's merge ref, not the default branch. GitHub's
+> repo-wide **Security → Code scanning** page (and its "Tool" filter) is scoped to the
+> default branch, so without at least one `push`-triggered analysis of `master`, OpenGrep
+> never appears there as a registered tool — even though PR runs succeed. This mirrors
+> GitHub's own official example workflows for third-party SARIF tools, which trigger on
+> `push`/`schedule`, not `pull_request` alone.
 
 ## Why OpenGrep (not Semgrep)?
 
@@ -27,6 +38,7 @@ workflow installs and drives the CLI directly.
    `opengrep`), plus a build artifact and a short job-summary count.
 
 ## Advisory-only (for now)
+
 
 The job runs with `continue-on-error: true`, so findings are visible (Security tab, job
 summary, artifact) but **never fail the PR check or block merge**. This is intentional

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ tools/          # PowerShell scripts (e.g., Entra app registration)
 - **Ingestion-ready data model** — normalized registration and attendance records are persisted locally and remain the foundation for follow-on ingestion work.
 - **Metrics persisted on write** — all metric aggregations are computed and stored on write; no compute-on-read.
 - **Delegated-only Graph permissions** — authenticated user context is required for supported directory lookups.
-- **Automated security scanning** — [OpenGrep](https://github.com/opengrep/opengrep) SAST scan runs on every pull request to `master` (advisory-only). See [`docs/opengrep-scanning.md`](docs/opengrep-scanning.md).
+- **Automated security scanning** — [OpenGrep](https://github.com/opengrep/opengrep) SAST scan runs on PRs to `master`, pushes to `master`, and weekly (advisory-only). See [`docs/opengrep-scanning.md`](docs/opengrep-scanning.md).
 
 ---
 


### PR DESCRIPTION
Incorporate push and schedule triggers into the OpenGrep workflow to ensure comprehensive security scanning on the default branch. This change allows for baseline analysis on pushes and weekly updates to capture any drift from upstream rule changes. The workflow remains advisory-only, ensuring findings are visible without blocking merges.