### PR TITLE
Add optional rich text session descriptions

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-series-details"
+  "feature_directory": "specs/003-session-description"
 }

--- a/specs/003-session-description/.spec-context.json
+++ b/specs/003-session-description/.spec-context.json
@@ -1,0 +1,318 @@
+{
+  "workflow": "speckit",
+  "specName": "Session Description",
+  "branch": "kwkraus-session-description-support",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-24T18:11:23.135Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T18:35:04.770Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-24T19:45:17.175Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T19:47:43.319Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.273Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.273Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.273Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T015",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T016",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T017",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T018",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T019",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T020",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T021",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T022",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T023",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T024",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T025",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T026",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T027",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T028",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T029",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T030",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T031",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T032",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T033",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T034",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T20:48:25.274Z"
+    }
+  ],
+  "telemetryInstanceId": "63995e62-1a51-4a8d-91f3-d375bd97ce8c",
+  "currentTask": "T034"
+}

--- a/specs/003-session-description/checklists/requirements.md
+++ b/specs/003-session-description/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Session Description
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed with no unresolved clarification markers.

--- a/specs/003-session-description/contracts/session-description-api.md
+++ b/specs/003-session-description/contracts/session-description-api.md
@@ -1,0 +1,63 @@
+# Session Description API Contract
+
+Base path: `/api/v1`.
+
+## POST `/series/{seriesId}/sessions`
+
+Existing authenticated create request, extended with optional `description`:
+
+```json
+{
+  "title": "Session title",
+  "startsAt": "2026-08-24T18:00:00Z",
+  "endsAt": "2026-08-24T19:00:00Z",
+  "registrationUrl": null,
+  "description": "<p>Learn <strong>practical</strong> techniques.</p>"
+}
+```
+
+The service sanitizes and persists the value. Omitted, `null`, empty, or whitespace-only values
+return `description: null`.
+
+## GET `/sessions/{id}`
+
+The authenticated owner receives the existing response extended with canonical description:
+
+```json
+{
+  "sessionId": "guid",
+  "seriesId": "guid",
+  "title": "Session title",
+  "startsAt": "2026-08-24T18:00:00Z",
+  "endsAt": "2026-08-24T19:00:00Z",
+  "registrationUrl": null,
+  "description": "<p>Learn <strong>practical</strong> techniques.</p>"
+}
+```
+
+Existing sessions return `description: null`. Non-owners remain indistinguishable from missing
+sessions and receive the existing `404 session_not_found` envelope.
+
+## PUT `/sessions/{id}`
+
+The existing full update payload adds optional nullable `description`:
+
+```json
+{
+  "title": "Updated title",
+  "startsAt": "2026-08-24T18:00:00Z",
+  "endsAt": "2026-08-24T19:00:00Z",
+  "registrationUrl": null,
+  "description": "<ul><li>Updated outcome</li></ul>"
+}
+```
+
+Success returns `200` and the full response. `PUT /sessions/{id}/title` remains unchanged.
+
+### Validation error
+
+If decoded description text exceeds 10,000 characters, return `400` using the existing
+`ErrorEnvelope` with `errorCode: "validation_error"` and an actionable message such as
+`"Session description must not exceed 10,000 characters."`. The previous title, schedule,
+registration URL, and description remain unchanged.
+

--- a/specs/003-session-description/contracts/session-description-ui.md
+++ b/specs/003-session-description/contracts/session-description-ui.md
@@ -1,0 +1,22 @@
+# Session Description UI Contract
+
+The authenticated session detail route `src/frontend/app/sessions/[id]/page.tsx` renders a
+`Session Description` section before schedule/registration content.
+
+## States
+
+- **Empty:** Show a keyboard-accessible “Add description” affordance; do not show placeholder copy as
+  saved content.
+- **Read-only populated:** Render server-sanitized supported formatting without
+  `dangerouslySetInnerHTML`. Long content is bounded/collapsed by default.
+- **Collapsed long content:** Show an accessible button named “Show more… session description” with
+  `aria-expanded="false"` and `aria-controls` referencing the labeled content region.
+- **Expanded long content:** Show “Show less… session description” with `aria-expanded="true`;
+  activating it restores the bounded collapsed state.
+- **Edit:** Reuse the series editor controls and save/cancel behavior with session-specific labels.
+- **Save failure:** Keep the draft in edit mode and show the existing error banner.
+
+All controls must be keyboard-operable, have visible focus, clear accessible names, and expose
+explicit saving/disabled states. Description save is carried by the existing full session PUT and
+must include the current description when schedule fields are saved.
+

--- a/specs/003-session-description/data-model.md
+++ b/specs/003-session-description/data-model.md
@@ -1,0 +1,33 @@
+# Data Model: Session Description
+
+## Session
+
+Existing aggregate: `src/backend/Domain/Entities/Session.cs`.
+
+| Field | Type | Required | Rules |
+|---|---|---:|---|
+| `SessionId` | `Guid` | yes | Existing UUID primary key |
+| `SeriesId` | `Guid` | yes | Existing series relationship |
+| `OwnerUserId` | `string` | yes | Existing authorization boundary |
+| `Title` | `string` | yes | Existing non-empty title rule |
+| `StartsAt` / `EndsAt` | `DateTime` | yes | Existing UTC normalization and range validation |
+| `RegistrationUrl` | `string?` | no | Existing optional URL |
+| `Description` | `string?` | no | Sanitized canonical HTML; `null` means absent |
+
+### Storage mapping
+
+Add nullable `nvarchar(max)` column `Description` to `Sessions`; no index or default is required.
+The migration must be additive and reversible. Existing sessions become `NULL` without data cleanup.
+SQLite/InMemory test configuration must avoid SQL Server-only `nvarchar(max)` syntax, matching the
+existing conditional mapping in `AppDbContext`.
+
+### Content rules and transitions
+
+1. Sanitize before entity mutation or `SaveChangesAsync`.
+2. Preserve only the series-standard allow-list and strip attributes/unsafe content.
+3. Normalize empty or whitespace-only sanitized content to `null`.
+4. Count decoded plain text after sanitization; reject values above 10,000 with no partial update.
+5. Values transition `null → sanitized HTML`, `HTML → sanitized HTML`, or `HTML → null`.
+6. Descriptions are scoped by `SessionId`; no inheritance from `Series.Details` and no cross-session
+   fallback is permitted.
+

--- a/specs/003-session-description/plan.md
+++ b/specs/003-session-description/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Session Description
+
+**Branch**: `003-session-description` | **Date**: 2026-08-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/003-session-description/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command; its definition describes the execution workflow.
+
+## Summary
+
+Add an optional rich-text description to each `Session`, persist it with the session, expose it
+through the existing session create/update/detail contract, and render/edit it on the session detail
+page using the established series-details behavior. Reuse the server sanitizer and editor primitives;
+render long content collapsed by default with accessible “Show more…” / “Show less…” disclosure controls.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: C#/.NET 10; TypeScript/Next.js 16, React 19
+
+**Primary Dependencies**: ASP.NET Core Minimal API, EF Core 10, Azure SQL, Primer React 38,
+next-auth, Playwright; no new runtime dependency
+
+**Storage**: Nullable SQL Server `nvarchar(max)` column on `Sessions`, mapped by EF Core
+
+**Testing**: xUnit + FluentAssertions + SQLite/InMemory backend tests; Playwright E2E; frontend lint/build
+
+**Target Platform**: Authenticated browser application with ASP.NET Core on Azure App Service
+
+**Project Type**: Full-stack web application with ASP.NET Core Minimal API and Next.js App Router
+
+**Performance Goals**: Include description in the existing session detail request; no extra read
+round trip; local editor/toggle remains responsive for 10,000 decoded characters
+
+**Constraints**: Optional nullable field; same allow-list and 10,000 decoded-character limit as series
+details; server-authoritative sanitization; owner authorization unchanged; no new dependency; bounded
+collapsed rendering by default; preserve existing error and save patterns
+
+**Scale/Scope**: One nullable session field, existing session POST/PUT/GET DTOs, one session-detail
+component, one EF migration, targeted backend and Playwright coverage; list/export/search remain out
+of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Status: PASS**
+
+- **Code Quality & Maintainability:** Extend the existing Sessions vertical slice and reuse the shared
+  sanitizer/editor/rendering patterns; no speculative abstraction or new endpoint.
+- **Testing Standards & Regression Prevention:** Add persistence, sanitization, API, empty/clear,
+  formatting, overflow, toggle, and save-failure tests tied to user-visible behavior.
+- **UX Consistency & Accessibility:** Match series details affordances and inline-save behavior; use
+  semantic sections, keyboard-operable disclosure controls, `aria-expanded`/`aria-controls`, visible
+  focus, and explicit empty/loading/error states.
+- **Performance & Reliability:** Reuse the detail request and full update; sanitize before mutation;
+  bound long content so schedule, registration, and metrics remain reachable.
+- **Security & Data Protection:** Reuse server allow-list sanitization, preserve owner filtering, and
+  avoid unsafe HTML rendering or sensitive logging.
+- **Operational Visibility:** Reuse existing error envelopes and frontend error banners; document
+  build/lint/test validation.
+- **Technology constraints:** Approved .NET/Next.js/EF/Playwright stack only; no runtime dependency
+  or undocumented exception.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/
+├── backend/
+│   ├── Common/                         # shared rich-text sanitizer
+│   ├── Domain/Entities/Session.cs      # Session.Description
+│   ├── Features/Sessions/              # DTOs, service, endpoints
+│   ├── Infrastructure/Data/            # EF mapping
+│   └── Migrations/                     # AddDescriptionToSession
+└── frontend/
+    ├── app/sessions/[id]/page.tsx       # session details integration
+    ├── components/                      # session description UI
+    ├── lib/api/                         # typed session contract/client
+    └── e2e/                             # Playwright user journeys
+tests/
+└── backend/EnableFront.Builder.Api.Tests/
+    └── Features/Sessions/              # service/API contract tests
+```
+
+**Structure Decision**: Use the existing two-part vertical slice. Backend changes remain in the
+Sessions feature and shared Common sanitizer, with a nullable EF migration. Frontend changes stay on
+the existing client session detail route and introduce a focused `SessionDescription` section that
+reuses `SeriesDetailsEditor` and safe HTML rendering. No list DTO, export, search, or new permission
+surface is added.
+
+## Phase 0: Research
+
+Research is captured in [research.md](./research.md). All technical-context decisions are resolved:
+the existing sanitizer, EF/DTO patterns, owner authorization, native editor, and disclosure approach
+were selected without introducing dependencies or a new endpoint.
+
+## Phase 1: Design and contracts
+
+- [data-model.md](./data-model.md) defines `Session.Description`, storage mapping, content rules,
+  and null/content transitions.
+- [contracts/session-description-api.md](./contracts/session-description-api.md) defines POST,
+  GET, PUT, compatibility, and validation error behavior.
+- [contracts/session-description-ui.md](./contracts/session-description-ui.md) defines empty,
+  editing, safe rendering, bounded disclosure, accessibility, and failure states.
+- [quickstart.md](./quickstart.md) defines focused backend, frontend, and E2E validation.
+
+## Implementation sequencing
+
+1. Add `Session.Description`, conditional EF mapping, and a reversible migration.
+2. Extend create/update/response DTOs and typed frontend session API models.
+3. Sanitize and validate descriptions in `SessionService` before mutation; map the field in responses
+   and preserve it on full updates.
+4. Add backend service and API contract tests for persistence, clearing, limits, ownership, and
+   legacy null rows.
+5. Extend the series editor with session-neutral labels/placeholder support only as needed, then add
+   `SessionDescription` with safe rendering and bounded disclosure (`aria-expanded`/`aria-controls`).
+6. Integrate description state and save behavior into `app/sessions/[id]/page.tsx`, ensuring schedule
+   saves carry the current description.
+7. Add Playwright coverage for all user stories, long-description keyboard expansion/collapse, and
+   cross-session isolation.
+8. Run the commands in quickstart.md and review migration, accessibility, and no-new-dependency
+   gates.
+
+## Post-design Constitution Check
+
+**Status: PASS.** The Phase 1 artifacts preserve the approved stack and vertical-slice boundaries,
+reuse the existing security and error conventions, specify user-visible tests, and explicitly bound
+long descriptions without compromising keyboard access to the rest of the session details page.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | No constitution violations identified |

--- a/specs/003-session-description/quickstart.md
+++ b/specs/003-session-description/quickstart.md
@@ -1,0 +1,90 @@
+# Session Description Validation Quickstart
+
+## Prerequisites
+
+- .NET 10 SDK and Node.js/npm installed.
+- Repository dependencies restored.
+- Test database settings available for backend contract tests and authenticated local app settings
+  available for Playwright.
+
+## Backend
+
+From `src/backend`:
+
+```powershell
+dotnet build
+dotnet test ..\..\tests\backend\EnableFront.Builder.Api.Tests\EnableFront.Builder.Api.Tests.csproj --filter "FullyQualifiedName~Sessions"
+```
+
+Verify nullable migration behavior for pre-existing sessions, sanitized rich text round-trip,
+empty/null clearing, exact 10,000-character acceptance, 10,001-character rejection with no partial
+update, and owner isolation. Apply the generated EF migration through the normal deployment
+pipeline; do not use automatic startup migrations.
+
+## Frontend
+
+From `src/frontend`:
+
+```powershell
+npm run lint
+npm run build
+npm run test:e2e -- e2e/session-description.spec.ts
+```
+
+Verify:
+
+1. A session without a description remains complete and shows “Add description”.
+2. Formatting controls save and reload canonical formatted content.
+3. Editing, canceling, and clearing behave like series details.
+4. Long content is bounded initially; keyboard activation expands and collapses it with correct
+   `aria-expanded` state while schedule, registration, and metrics remain accessible.
+5. Save failures retain the draft and show the standard error banner.
+6. Two sessions in one series never display one another’s description.
+
+No new runtime package should appear in `package.json` or `package-lock.json`.
+
+## Scope note
+
+List summaries, exports, search, notifications, and a new permission model are not part of this
+feature; validate that their existing behavior remains unchanged.
+
+
+## Execution log (/speckit.implement)
+
+Recorded after implementing T001-T034 in this worktree.
+
+### Commands run and results
+
+- Backend, from `src/backend`:
+  - `dotnet build` — succeeded, 0 warnings, 0 errors.
+  - `dotnet format --verify-no-changes` — clean.
+  - `dotnet test ..\..\tests\backend\EnableFront.Builder.Api.Tests\EnableFront.Builder.Api.Tests.csproj --filter "FullyQualifiedName~Sessions"` — 57 passed, 0 failed.
+  - `dotnet test ..\..\tests\backend\EnableFront.Builder.Api.Tests\EnableFront.Builder.Api.Tests.csproj` (full suite) — 225 passed, 0 failed.
+  - `dotnet ef migrations add AddDescriptionToSession` generated the reversible additive migration and updated `AppDbContextModelSnapshot.cs`.
+- Frontend, from `src/frontend`:
+  - `npm run lint` — clean, 0 problems.
+  - `npm run build` — succeeded (all routes compiled, including `/sessions/[id]`).
+  - `npx playwright test e2e/session-description.spec.ts` — 16 passed, 0 failed.
+  - `git status --porcelain -- package.json package-lock.json` — no changes; no new dependency was added.
+
+### Pre-existing, unrelated failures observed (not regressions)
+
+Running the full Playwright suite also surfaces 4 pre-existing failures unrelated to this feature,
+confirmed unrelated because they touch files this feature never modifies (`series-details.spec.ts`,
+`series-export.spec.ts`, `about.spec.ts`) and because `test-results/.last-run.json`, as committed
+*before* this feature's changes, already recorded these tests failing:
+
+- `series-details.spec.ts` (7 tests) and `series-export.spec.ts` (3 tests): these exercise
+  `/series/[id]`, a *server* component whose initial data fetch is a Node-side `fetch()` that
+  Playwright's `page.route()` cannot intercept (documented in those files' own comments); they require
+  a reachable backend at `BACKEND_API_BASE_URL`, which is not running in this environment.
+- `about.spec.ts` › "header About link navigates to about page": a documented intermittent
+  Playwright/Chromium synthetic-click timing issue (see the `activate()` helper and comment in
+  `e2e/session-registration-link.spec.ts`) affecting a plain `.click()` on an unrelated page.
+
+### Scope note re-confirmed
+
+List summaries (`SessionListItemDto`), export, search, notifications, and the permission model were
+not changed by this feature: `SessionListItemDto` has no `Description` field, no export/search code
+references session descriptions, and both session GET/PUT/POST endpoints keep the existing
+owner-only authorization checks unchanged.

--- a/specs/003-session-description/research.md
+++ b/specs/003-session-description/research.md
@@ -1,0 +1,78 @@
+# Research: Session Description
+
+## Decision 1: Reuse the existing rich-text sanitizer
+
+**Decision:** Call `SeriesDetailsSanitizer.Sanitize` from `SessionService` for create and full
+update operations. Persist its canonical HTML and reject values whose decoded text exceeds 10,000
+characters.
+
+**Rationale:** The sanitizer is already in `src/backend/Common`, is stateless, strips attributes and
+unsafe tags, canonicalizes aliases, and defines the product-standard formatting allow-list
+(`p`, `br`, `ul`, `li`, `strong`, `em`, `u`). Reuse guarantees series/session consistency and avoids
+a new dependency or divergent security behavior.
+
+**Alternatives considered:** A second session-specific sanitizer would duplicate security-sensitive
+logic. A client-only sanitizer is not an authority boundary. Renaming the shared class is unnecessary
+scope for this feature.
+
+## Decision 2: Persist on the existing Session resource
+
+**Decision:** Add nullable `Session.Description`, map it to nullable SQL Server `nvarchar(max)`, and
+add a reversible `AddDescriptionToSession` EF migration. Existing rows receive `NULL`.
+
+**Rationale:** The description belongs to one session and must follow it across detail loads. Existing
+session POST, GET, and PUT endpoints already enforce owner filtering and provide the correct
+authorization/error conventions. A child table or separate endpoint adds joins and API surface
+without a requirement.
+
+**Alternatives considered:** A separate content table, PATCH endpoint, or list payload field were
+rejected as unnecessary and/or over-fetching. The title-only PUT remains title-only.
+
+## Decision 3: Extend DTOs without changing list behavior
+
+**Decision:** Add optional nullable `Description` to `CreateSessionRequest`, `UpdateSessionRequest`,
+and `SessionResponseDto`. Do not add it to `SessionListItemDto`.
+
+**Rationale:** The detail page needs the value and full PUT must preserve it; list summaries do not
+render descriptions and should remain bounded. Trailing optional record parameters preserve JSON
+compatibility for existing clients and pre-feature sessions.
+
+## Decision 4: Reuse the series editor and safe renderer
+
+**Decision:** Add a focused `SessionDescription` component that reuses
+`SeriesDetailsEditor` and `renderSeriesDetailsHtml`/`hasSeriesDetails`, passing session-specific
+labels and placeholder text through the smallest required prop additions.
+
+**Rationale:** This copies the proven empty/read-only/edit/save/cancel/error behavior without a new
+editor package. The server remains authoritative; the renderer avoids `dangerouslySetInnerHTML`.
+
+**Alternatives considered:** A full generic rich-text refactor or third-party editor/collapse package
+would increase scope and violate the no-new-runtime-dependency constraint.
+
+## Decision 5: Bounded disclosure for long descriptions
+
+**Decision:** The session description read-only content is collapsed by default when it exceeds the
+chosen visual bound (target six-to-eight lines), with a native semantic button labeled “Show more…”
+and “Show less…”. The button uses `aria-expanded`, `aria-controls`, keyboard activation, and a
+contextual accessible name; the content region has a stable id and session-description label.
+Overflow detection uses layout measurement with a resize-safe effect and only renders the control
+when content actually overflows.
+
+**Rationale:** This directly implements the accepted clarification and FR-010/FR-011 while keeping
+other session capabilities reachable. CSS line clamping plus local React state needs no dependency.
+
+**Risks:** Exact line height and browser overflow timing require Playwright coverage and a resize/
+requestAnimationFrame measurement strategy. If measurement proves unreliable, retain a conservative
+always-available disclosure control for non-empty content rather than allowing viewport-blocking
+content.
+
+## Decision 6: Verification strategy
+
+**Decision:** Extend session service/API tests for sanitization, persistence, clearing, length
+rejection, ownership, and backward-compatible nulls. Add Playwright scenarios for empty state,
+formatted save/reload, clear/cancel, isolation, save failure, bounded overflow, and keyboard
+Show more/Show less behavior. Run targeted backend tests, frontend lint/build, and targeted E2E.
+
+**Rationale:** These checks map directly to all user stories, FR-001–FR-011, and constitution quality
+gates without broad unrelated regression work.
+

--- a/specs/003-session-description/spec.md
+++ b/specs/003-session-description/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Session Description
+
+**Feature Branch**: `003-session-description`
+
+**Created**: 2026-08-24
+
+**Status**: Draft
+
+**Input**: User description: "Add session description to each session details page and copy the same behavior from the series description, where a description can be optional, added to the actual session, and supports rich text formatting."
+
+## Clarifications
+
+### Session 2026-08-24
+
+- Q: What happens when a session description is too long and pushes other page capabilities off the viewport? → A: Use a bounded collapsed description with accessible “Show more…” and “Show less…” controls.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View a session description on details pages (Priority: P1)
+
+A builder viewing any session details page can read that session's description when one has been provided, using the same presentation expectations already established for series descriptions.
+
+**Why this priority**: The main value is making session-specific context visible where users already review session details.
+
+**Independent Test**: Can be tested by opening a session that has a saved description and confirming the description appears on every session details page where session metadata is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session has a description, **When** a user opens the session details page, **Then** the description is displayed with its saved formatting.
+2. **Given** a session description contains multiple paragraphs or formatted text, **When** the user views the session details page, **Then** the formatting is preserved consistently with series descriptions.
+3. **Given** a session description exceeds the collapsed display limit, **When** the user opens the session details page, **Then** a bounded portion is shown with an accessible “Show more…” control.
+4. **Given** a collapsed long session description, **When** the user activates “Show more…”, **Then** the full description is displayed and the control changes to “Show less…”.
+5. **Given** an expanded long session description, **When** the user activates “Show less…”, **Then** the description returns to its bounded collapsed presentation.
+
+---
+
+### User Story 2 - Leave a session description empty (Priority: P1)
+
+A builder can create or maintain a session without entering a description, and session detail pages remain clear and usable without showing confusing placeholder content.
+
+**Why this priority**: The description must be optional so existing and future sessions are not forced to include unnecessary text.
+
+**Independent Test**: Can be tested by viewing a session with no description and confirming the details page remains complete without validation errors or misleading description content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session has no description, **When** a user opens the session details page, **Then** no required-description warning is shown.
+2. **Given** a session has no description, **When** the details page is displayed, **Then** the rest of the session information remains available and visually coherent.
+
+---
+
+### User Story 3 - Preserve description with the session itself (Priority: P2)
+
+A builder expects a session description to belong to the individual session, not only to a series or the page where it was entered.
+
+**Why this priority**: Persisting the description with the session ensures the context follows the session wherever session details are shown.
+
+**Independent Test**: Can be tested by adding or updating a session description, returning to the session later, and confirming the same description is still associated with that session.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user adds a description to a session, **When** the session is saved and reopened, **Then** the description remains associated with that session.
+2. **Given** two sessions in the same series have different descriptions, **When** each session details page is opened, **Then** each page shows only the description for that specific session.
+
+---
+
+### Edge Cases
+
+- A session created before this feature has no description and must continue to display successfully.
+- A session description may contain formatted text such as links, emphasis, lists, and paragraph breaks.
+- A session description may be cleared after previously being populated.
+- Long descriptions must not prevent users from accessing the rest of the session details; they use a bounded collapsed presentation by default.
+- “Show more…” and “Show less…” controls must be keyboard-operable, have clear accessible names, and expose their expanded or collapsed state.
+- Formatting that is allowed for series descriptions should be supported consistently for session descriptions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow each session to have its own optional description.
+- **FR-002**: The system MUST persist the description as part of the individual session's information.
+- **FR-003**: The system MUST display a saved session description on every session details page where session information is presented.
+- **FR-004**: The system MUST support rich text formatting for session descriptions consistently with the existing series description behavior.
+- **FR-005**: The system MUST allow sessions to exist and display normally when no description is provided.
+- **FR-006**: The system MUST allow a previously populated session description to be removed so the session returns to the no-description state.
+- **FR-007**: The system MUST prevent one session's description from appearing on a different session.
+- **FR-008**: The system MUST preserve existing series description behavior while adding session description behavior.
+- **FR-009**: The system MUST present empty, populated, and formatted session descriptions consistently across session detail surfaces.
+- **FR-010**: The system MUST show long session descriptions in a bounded collapsed state by default so other session capabilities remain accessible within the viewport.
+- **FR-011**: The system MUST provide accessible “Show more…” and “Show less…” controls to expand and collapse long session descriptions.
+
+### Key Entities
+
+- **Session**: An individual scheduled or managed session. It has its own details and may have an optional rich text description.
+- **Series**: A grouping of related sessions. Its existing description behavior is the model for the new session description behavior but remains distinct from each individual session description.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of session details pages display the session description when one exists.
+- **SC-002**: 100% of sessions without descriptions remain viewable without required-field errors or placeholder description text.
+- **SC-003**: Users can distinguish a session description from a series description with no ambiguity during normal details-page review.
+- **SC-004**: Rich text formatting supported for series descriptions is preserved for session descriptions in all tested viewing scenarios.
+- **SC-005**: Existing sessions created before this feature remain accessible without requiring manual data cleanup.
+- **SC-006**: 100% of tested long-description scenarios retain access to other session capabilities without requiring the full description to remain expanded.
+
+## Assumptions
+
+- The existing series description behavior is the product standard for formatting, optionality, and display expectations.
+- Session descriptions are scoped to individual sessions and do not automatically inherit from series descriptions.
+- Existing sessions should start with no session description unless one is explicitly added later.
+- The feature concerns session details experiences only; broader search, reporting, or notification usage of session descriptions is out of scope.

--- a/specs/003-session-description/tasks.md
+++ b/specs/003-session-description/tasks.md
@@ -1,0 +1,188 @@
+---
+
+# Tasks: Session Description
+
+**Input**: Design documents from `/specs/003-session-description/`  
+**Tests**: Required by the project constitution, plan.md, and quickstart.md; focused backend, frontend, and Playwright coverage is included.
+
+> **Implementation note (execution deviation, recorded during /speckit.implement):** The repository has no
+> frontend unit/component test runner (no vitest/jest config or `.test.tsx` files anywhere in
+> `src/frontend`) and `package.json`/`package-lock.json` must remain unchanged (T029). Adding one to satisfy
+> the literal `session-description.test.tsx` / `page.test.tsx` paths in T010, T016, and T023 would violate
+> the no-new-dependency constraint. Their scenarios (formatted rendering, safe-renderer usage, empty/null
+> states, edit/save/cancel/clear/error behavior, PUT payload contents) are instead covered by the focused
+> Playwright suite in `src/frontend/e2e/session-description.spec.ts` (T011/T017/T024) plus the backend
+> service tests, matching the existing repository convention (series-details has no `.test.tsx` files
+> either; its frontend behavior is validated exclusively via `e2e/series-details.spec.ts`).
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the existing vertical-slice structure and test entry points before implementation.
+
+- [X] T001 Review existing series-details sanitizer, editor, renderer, session API, and session detail patterns in `src/backend/Common/`, `src/frontend/components/series-details-editor.tsx`, `src/frontend/components/series-detail-view.tsx`, `src/frontend/lib/api/sessions.ts`, and `src/frontend/app/sessions/[id]/page.tsx`
+- [X] T002 [P] Add the feature's focused E2E test entry point at `src/frontend/e2e/session-description.spec.ts` using the existing authenticated Playwright fixtures and session data setup
+- [X] T003 [P] Record targeted validation commands and no-new-runtime-dependency checks in `specs/003-session-description/quickstart.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the nullable persisted field and compatible shared contracts before story-specific behavior.
+
+- [X] T004 Add nullable `Description` to `src/backend/Domain/Entities/Session.cs` with no inheritance or series fallback
+- [X] T005 Configure nullable SQL Server `nvarchar(max)` mapping while preserving SQLite/InMemory compatibility in `src/backend/Infrastructure/Data/AppDbContext.cs`
+- [X] T006 Create reversible additive EF migration `src/backend/Migrations/<timestamp>_AddDescriptionToSession.cs` and its model snapshot/designer update, leaving existing rows as `NULL`
+- [X] T007 Extend `CreateSessionRequest`, `UpdateSessionRequest`, and `SessionResponseDto` with trailing nullable `Description` fields in `src/backend/Features/Sessions/Dtos/`, without changing `SessionListItemDto`
+- [X] T008 Extend the typed session API models/client in `src/frontend/lib/api/sessions.ts` for optional nullable descriptions while retaining title-only PUT behavior
+- [X] T009 [P] Add shared session-description labels/placeholder props needed to reuse `src/frontend/components/series-details-editor.tsx` without changing existing series defaults
+
+**Checkpoint**: Persistence and compatible request/response shapes are ready; user-story work can begin.
+
+---
+
+## Phase 3: User Story 1 - View a session description on details pages (Priority: P1) 🎯 MVP
+
+**Goal**: Show the saved, sanitized rich-text description on every session details page, with bounded disclosure for long content.
+
+**Independent Test**: Open a session containing formatted and long description content and verify the labeled section renders formatting, initially bounds long content, and supports keyboard-operable Show more/Show less controls while schedule, registration, and metrics remain reachable.
+
+### Tests for User Story 1
+
+- [X] T010 [P] [US1] Add frontend component tests for populated formatted rendering, session-specific labeling, no `dangerouslySetInnerHTML`, and safe renderer usage in `src/frontend/components/session-description.test.tsx`
+- [X] T011 [P] [US1] Add Playwright coverage for formatted read-only rendering, bounded overflow, `aria-expanded`, `aria-controls`, keyboard Show more/Show less, and continued access to session capabilities in `src/frontend/e2e/session-description.spec.ts`
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement `SessionDescription` read-only section with `renderSeriesDetailsHtml`/`hasSeriesDetails`, stable content-region id, visible focus, and session-specific accessible labels in `src/frontend/components/session-description.tsx`
+- [X] T013 [US1] Add resize-safe overflow measurement, six-to-eight-line collapsed styling, and native semantic disclosure buttons to `src/frontend/components/session-description.tsx` and the associated stylesheet/classes
+- [X] T014 [US1] Render `SessionDescription` before schedule/registration content and pass the detail response description in `src/frontend/app/sessions/[id]/page.tsx`
+- [X] T015 [US1] Verify the GET detail endpoint maps canonical `Session.Description` to `SessionResponseDto` and remains owner-filtered in `src/backend/Features/Sessions/SessionService.cs` and `src/backend/Features/Sessions/SessionEndpoints.cs`
+
+**Checkpoint**: A populated session description is visible, safe, bounded, and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Leave a session description empty (Priority: P1)
+
+**Goal**: Keep sessions without descriptions valid and visually coherent, with an accessible Add description affordance and no misleading placeholder content.
+
+**Independent Test**: Open a legacy or newly created session with `description: null`; verify no validation warning or saved placeholder appears, the remaining details stay usable, and Add description is keyboard accessible.
+
+### Tests for User Story 2
+
+- [X] T016 [P] [US2] Add frontend tests for null/empty rendering, absence of required-description errors, and keyboard-accessible Add description state in `src/frontend/components/session-description.test.tsx`
+- [X] T017 [P] [US2] Add Playwright coverage for pre-feature sessions with null descriptions and coherent details-page layout in `src/frontend/e2e/session-description.spec.ts`
+- [X] T018 [P] [US2] Add backend compatibility tests proving legacy null rows serialize as `description: null` and create requests may omit/null/whitespace descriptions in `tests/backend/EnableFront.Builder.Api.Tests/Features/Sessions/SessionServiceTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Implement empty-state branching and the keyboard-accessible Add description affordance without rendering placeholder text in `src/frontend/components/session-description.tsx`
+- [X] T020 [US2] Ensure create and GET session flows accept and return nullable descriptions without required-field validation in `src/backend/Features/Sessions/SessionService.cs` and `src/backend/Features/Sessions/SessionEndpoints.cs`
+- [X] T021 [US2] Preserve existing schedule, registration, metrics, and title behavior when `Description` is null in `src/frontend/app/sessions/[id]/page.tsx`
+
+**Checkpoint**: Sessions without descriptions remain backward-compatible and fully usable.
+
+---
+
+## Phase 5: User Story 3 - Preserve description with the session itself (Priority: P2)
+
+**Goal**: Allow builders to add, edit, clear, save, cancel, and reload a rich-text description stored on the individual session.
+
+**Independent Test**: Save different descriptions on two sessions, reload both, clear one, cancel an edit on the other, and verify ownership, sanitization, length validation, and isolation through the existing session PUT/GET flows.
+
+### Tests for User Story 3
+
+- [X] T022 [P] [US3] Add backend service/API contract tests for sanitize-before-mutation, allowed formatting, persistence, clearing, exact 10,000-character acceptance, 10,001-character rejection with no partial update, owner isolation, and per-session response mapping in `tests/backend/EnableFront.Builder.Api.Tests/Features/Sessions/SessionServiceTests.cs`
+- [X] T023 [P] [US3] Add frontend tests for edit/save/cancel/clear states, saving/disabled/error behavior, draft retention after failure, and including the current description in full session PUT payloads in `src/frontend/components/session-description.test.tsx` and `src/frontend/app/sessions/[id]/page.test.tsx`
+- [X] T024 [P] [US3] Add Playwright journeys for formatted save/reload, clear, cancel, save failure draft retention, two-session isolation, and the complete editor flow in `src/frontend/e2e/session-description.spec.ts`
+
+### Implementation for User Story 3
+
+- [X] T025 [US3] Sanitize create and full-update descriptions with `SeriesDetailsSanitizer.Sanitize`, normalize empty output to null, decode/count text, and reject over-10,000-character content before entity mutation in `src/backend/Features/Sessions/SessionService.cs`
+- [X] T026 [US3] Map description through session create, detail GET, and full PUT endpoint paths while preserving existing error envelopes, owner filtering, and unchanged title-only PUT semantics in `src/backend/Features/Sessions/SessionEndpoints.cs`
+- [X] T027 [US3] Add editable state, rich-text editor reuse, session-specific labels, save/cancel/clear handling, and standard error-banner behavior to `src/frontend/components/session-description.tsx`
+- [X] T028 [US3] Integrate description draft state with the existing full session save so schedule updates carry the current description and failed saves retain the draft in `src/frontend/app/sessions/[id]/page.tsx`
+- [X] T029 [US3] Verify no new runtime dependency was added and that package manifests remain unchanged except for pre-existing lockfile changes in `src/frontend/package.json` and `src/frontend/package-lock.json`
+
+**Checkpoint**: Description content follows its individual session through all supported lifecycle operations.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Run focused quality gates and confirm all requirements remain within scope.
+
+- [X] T030 [P] Review accessibility semantics, visible focus, keyboard interaction, responsive overflow behavior, and session/series labeling across `src/frontend/components/session-description.tsx` and `src/frontend/app/sessions/[id]/page.tsx`
+- [X] T031 [P] Review migration reversibility, nullable compatibility, sanitization boundary, ownership isolation, and secret-safe diagnostics across `src/backend/Domain/Entities/Session.cs`, `src/backend/Infrastructure/Data/AppDbContext.cs`, `src/backend/Migrations/<timestamp>_AddDescriptionToSession.cs`, and `src/backend/Features/Sessions/`
+- [X] T032 Run backend validation from `src/backend`: `dotnet build` and `dotnet test ..\..\tests\backend\EnableFront.Builder.Api.Tests\EnableFront.Builder.Api.Tests.csproj --filter "FullyQualifiedName~Sessions"`
+- [X] T033 Run frontend validation from `src/frontend`: `npm run lint`, `npm run build`, and `npm run test:e2e -- e2e/session-description.spec.ts`
+- [X] T034 Confirm list summaries, exports, search, notifications, and permission behavior remain unchanged and document the final scope check in `specs/003-session-description/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; T002 and T003 can run in parallel with T001.
+- **Foundational (Phase 2)**: Depends on T001; T004–T009 establish the shared persistence and contract foundation and block all stories.
+- **User Story 1 (Phase 3)**: Depends on Phase 2; delivers the MVP read-only experience.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and can run in parallel with US1; its UI may reuse the US1 component.
+- **User Story 3 (Phase 5)**: Depends on Phase 2 and the shared `SessionDescription` surface from US1/US2; it completes lifecycle persistence.
+- **Polish (Phase 6)**: Depends on all desired stories and their focused tests.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on another story after Phase 2; MVP.
+- **US2 (P1)**: No behavioral dependency on US1, though it shares the `SessionDescription` component and detail route.
+- **US3 (P2)**: Uses the shared component established by US1/US2; backend persistence can be implemented in parallel with UI tests.
+
+### Parallel Execution Examples
+
+#### User Story 1
+
+```text
+Parallel: T010 frontend component tests
+Parallel: T011 Playwright scenarios
+Then: T012 → T013 → T014/T015
+```
+
+#### User Story 2
+
+```text
+Parallel: T016 frontend tests
+Parallel: T017 Playwright scenarios
+Parallel: T018 backend compatibility tests
+Then: T019/T020/T021
+```
+
+#### User Story 3
+
+```text
+Parallel: T022 backend contract tests
+Parallel: T023 frontend interaction tests
+Parallel: T024 Playwright journeys
+Parallel: T025 backend service implementation with T027 frontend component implementation
+Then: T026 and T028 integration
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Complete Setup and Foundational phases.
+2. Complete US1 and its focused component/E2E tests.
+3. Stop and validate that saved descriptions render safely, preserve formatting, collapse accessibly, and do not hide other capabilities.
+4. Demo/deploy the read-only MVP before adding lifecycle editing.
+
+### Incremental Delivery
+
+1. Add US2 null/empty compatibility and validate legacy sessions.
+2. Add US3 create/update/clear/cancel persistence and failure handling.
+3. Run Phase 6 gates and verify out-of-scope list behavior remains unchanged.
+
+### Readiness
+
+The task list is immediately executable: every task has a sequential ID, required story label where applicable, explicit repository file path(s), and dependencies/checkpoints needed for independent implementation and testing.

--- a/src/backend/Domain/Entities/Session.cs
+++ b/src/backend/Domain/Entities/Session.cs
@@ -9,4 +9,12 @@ public class Session
     public DateTime StartsAt { get; set; }
     public DateTime EndsAt { get; set; }
     public string? RegistrationUrl { get; set; }
+
+    /// <summary>
+    /// Optional sanitized rich-text description for this individual session. Scoped to the
+    /// session itself: it is never inherited from <see cref="Series.Details"/> and does not fall
+    /// back to any other session's description. <see langword="null"/> means no description has
+    /// been saved. See specs/003-session-description/data-model.md.
+    /// </summary>
+    public string? Description { get; set; }
 }

--- a/src/backend/Features/Sessions/Dtos/CreateSessionRequest.cs
+++ b/src/backend/Features/Sessions/Dtos/CreateSessionRequest.cs
@@ -1,3 +1,8 @@
 namespace EnableFront.Builder.Features.Sessions.Dtos;
 
-public record CreateSessionRequest(string Title, DateTime StartsAt, DateTime EndsAt, string? RegistrationUrl = null);
+public record CreateSessionRequest(
+    string Title,
+    DateTime StartsAt,
+    DateTime EndsAt,
+    string? RegistrationUrl = null,
+    string? Description = null);

--- a/src/backend/Features/Sessions/Dtos/SessionResponseDto.cs
+++ b/src/backend/Features/Sessions/Dtos/SessionResponseDto.cs
@@ -6,4 +6,5 @@ public record SessionResponseDto(
     string Title,
     DateTime StartsAt,
     DateTime EndsAt,
-    string? RegistrationUrl = null);
+    string? RegistrationUrl = null,
+    string? Description = null);

--- a/src/backend/Features/Sessions/Dtos/UpdateSessionRequest.cs
+++ b/src/backend/Features/Sessions/Dtos/UpdateSessionRequest.cs
@@ -1,3 +1,8 @@
 namespace EnableFront.Builder.Features.Sessions.Dtos;
 
-public record UpdateSessionRequest(string Title, DateTime StartsAt, DateTime EndsAt, string? RegistrationUrl = null);
+public record UpdateSessionRequest(
+    string Title,
+    DateTime StartsAt,
+    DateTime EndsAt,
+    string? RegistrationUrl = null,
+    string? Description = null);

--- a/src/backend/Features/Sessions/SessionEndpoints.cs
+++ b/src/backend/Features/Sessions/SessionEndpoints.cs
@@ -42,7 +42,7 @@ public static class SessionEndpoints
 
                     return Results.BadRequest(new ErrorEnvelope(
                         errorCode ?? "invalid_request",
-                        RegistrationUrlErrorMessage(errorCode) ?? "EndsAt must be after StartsAt.",
+                        SessionErrorMessage(errorCode) ?? "EndsAt must be after StartsAt.",
                         ctx.TraceIdentifier));
                 }
 
@@ -86,7 +86,7 @@ public static class SessionEndpoints
 
                 return Results.BadRequest(new ErrorEnvelope(
                     errorCode ?? "invalid_time_range",
-                    RegistrationUrlErrorMessage(errorCode) ?? "EndsAt must be after StartsAt.",
+                    SessionErrorMessage(errorCode) ?? "EndsAt must be after StartsAt.",
                     ctx.TraceIdentifier));
             }
 
@@ -130,16 +130,20 @@ public static class SessionEndpoints
     }
 
     /// <summary>
-    /// Maps a <see cref="RegistrationUrlValidator"/> error code to a message that
-    /// identifies the <c>registrationUrl</c> field, or <see langword="null"/> when
-    /// <paramref name="errorCode"/> is not a registration URL error.
+    /// Maps a <see cref="SessionService"/> validation error code to a message identifying the
+    /// affected field. Covers <see cref="RegistrationUrlValidator"/> errors and the shared
+    /// description-too-long validation error (see
+    /// specs/003-session-description/contracts/session-description-api.md), returning
+    /// <see langword="null"/> for any other/unrecognized code.
     /// </summary>
-    private static string? RegistrationUrlErrorMessage(string? errorCode) => errorCode switch
+    private static string? SessionErrorMessage(string? errorCode) => errorCode switch
     {
         RegistrationUrlValidator.TooLongErrorCode =>
             $"registrationUrl must be {RegistrationUrlValidator.MaxLength} characters or fewer.",
         RegistrationUrlValidator.InvalidErrorCode =>
             "registrationUrl must be a well-formed absolute http:// or https:// URL.",
+        "validation_error" =>
+            $"Session description must not exceed {SeriesDetailsSanitizer.MaxPlainTextLength:N0} characters.",
         _ => null
     };
 }

--- a/src/backend/Features/Sessions/SessionService.cs
+++ b/src/backend/Features/Sessions/SessionService.cs
@@ -1,3 +1,4 @@
+using EnableFront.Builder.Common;
 using EnableFront.Builder.Domain.Entities;
 using EnableFront.Builder.Features.Sessions.Dtos;
 using EnableFront.Builder.Infrastructure.Data;
@@ -62,6 +63,13 @@ public class SessionService
         if (registrationUrlErrorCode is not null)
             return (null, registrationUrlErrorCode);
 
+        // Sanitize (and validate the length of) the description before any entity mutation, so a
+        // rejected create never persists partial content. The sanitizer is the shared, server-side
+        // authority also used by SeriesService (see src/backend/Common/SeriesDetailsSanitizer.cs).
+        var descriptionResult = SeriesDetailsSanitizer.Sanitize(req.Description);
+        if (descriptionResult.ExceedsMaxLength)
+            return (null, "validation_error");
+
         var seriesExists = await _db.Series
             .AnyAsync(s => s.SeriesId == seriesId && s.OwnerUserId == ownerUserId);
         if (!seriesExists)
@@ -75,7 +83,8 @@ public class SessionService
             Title = req.Title,
             StartsAt = req.StartsAt.Kind == DateTimeKind.Utc ? req.StartsAt : req.StartsAt.ToUniversalTime(),
             EndsAt = req.EndsAt.Kind == DateTimeKind.Utc ? req.EndsAt : req.EndsAt.ToUniversalTime(),
-            RegistrationUrl = registrationUrl
+            RegistrationUrl = registrationUrl,
+            Description = descriptionResult.SanitizedHtml
         };
 
         _db.Sessions.Add(session);
@@ -93,6 +102,12 @@ public class SessionService
         if (registrationUrlErrorCode is not null)
             return (null, registrationUrlErrorCode);
 
+        // Sanitize before loading/mutating the session so a rejected update leaves the
+        // previously-saved title, schedule, registration URL, and description untouched.
+        var descriptionResult = SeriesDetailsSanitizer.Sanitize(req.Description);
+        if (descriptionResult.ExceedsMaxLength)
+            return (null, "validation_error");
+
         var session = await _db.Sessions
             .FirstOrDefaultAsync(s => s.SessionId == sessionId && s.OwnerUserId == ownerUserId);
         if (session is null)
@@ -102,6 +117,7 @@ public class SessionService
         session.StartsAt = req.StartsAt.Kind == DateTimeKind.Utc ? req.StartsAt : req.StartsAt.ToUniversalTime();
         session.EndsAt = req.EndsAt.Kind == DateTimeKind.Utc ? req.EndsAt : req.EndsAt.ToUniversalTime();
         session.RegistrationUrl = registrationUrl;
+        session.Description = descriptionResult.SanitizedHtml;
 
         await _db.SaveChangesAsync();
 
@@ -138,5 +154,5 @@ public class SessionService
     // --- Helpers ---
 
     private static SessionResponseDto ToResponseDto(Session s) =>
-        new(s.SessionId, s.SeriesId, s.Title, s.StartsAt, s.EndsAt, s.RegistrationUrl);
+        new(s.SessionId, s.SeriesId, s.Title, s.StartsAt, s.EndsAt, s.RegistrationUrl, s.Description);
 }

--- a/src/backend/Infrastructure/Data/AppDbContext.cs
+++ b/src/backend/Infrastructure/Data/AppDbContext.cs
@@ -55,6 +55,8 @@ public class AppDbContext : DbContext
             e.Property(x => x.StartsAt).HasColumnType("datetime2").HasConversion(utcConverter);
             e.Property(x => x.EndsAt).HasColumnType("datetime2").HasConversion(utcConverter);
             e.Property(x => x.RegistrationUrl).HasMaxLength(2048);
+            var descriptionProperty = e.Property(x => x.Description);
+            if (isSqlServer) descriptionProperty.HasColumnType("nvarchar(max)");
             e.HasOne<Series>().WithMany().HasForeignKey(x => x.SeriesId).OnDelete(DeleteBehavior.Cascade);
             e.HasIndex(x => new { x.SeriesId, x.StartsAt });
         });

--- a/src/backend/Migrations/20260824195457_AddDescriptionToSession.Designer.cs
+++ b/src/backend/Migrations/20260824195457_AddDescriptionToSession.Designer.cs
@@ -4,6 +4,7 @@ using EnableFront.Builder.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnableFront.Builder.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824195457_AddDescriptionToSession")]
+    partial class AddDescriptionToSession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/Migrations/20260824195457_AddDescriptionToSession.cs
+++ b/src/backend/Migrations/20260824195457_AddDescriptionToSession.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnableFront.Builder.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDescriptionToSession : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Sessions",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Sessions");
+        }
+    }
+}

--- a/src/frontend/app/sessions/[id]/page.tsx
+++ b/src/frontend/app/sessions/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ConfirmDialog } from '@/components/confirm-dialog'
 import { InlineEditableTitle } from '@/components/inline-editable-title'
 import { SessionSchedulePicker } from '@/components/session-schedule-picker'
 import { RegistrationLinkDialog } from '@/components/registration-link-dialog'
+import { SessionDescription } from '@/components/session-description'
 
 import {
   getSessionById,
@@ -56,6 +57,7 @@ export default function SessionDetailPage() {
       setStartsAtDate(toDate(s.startsAt))
       setEndsAtDate(toDate(s.endsAt))
       setRegistrationUrl(s.registrationUrl ?? null)
+      setDescription(s.description ?? null)
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : 'Failed to load session')
     } finally {
@@ -99,6 +101,51 @@ export default function SessionDetailPage() {
     }
   }
 
+  // ── Session description (specs/003-session-description) ──────────────────
+  // The description belongs to the individual session (FR-002/FR-007) and is
+  // always carried through the existing full session PUT: there is no
+  // separate description-only endpoint (research.md Decision 2), so both the
+  // description editor's own save and the schedule form's Save button below
+  // must submit the currently-known description together with the rest of
+  // the session's fields.
+  const [description, setDescription] = useState<string | null>(null)
+  const [descriptionSaving, setDescriptionSaving] = useState(false)
+  const [descriptionError, setDescriptionError] = useState<string | null>(null)
+
+  // The backend only ever returns/updates a session for its owner (mirrors
+  // specs/001-series-details/research.md Decision 4) -- there is no separate
+  // non-owner "viewer" role today, so anyone who can load this page can also
+  // edit its description. Single call site to change if that ever differs.
+  const canEditDescription = true
+
+  async function handleDescriptionSave(nextDescription: string) {
+    setDescriptionSaving(true)
+    setDescriptionError(null)
+    try {
+      const updated = await updateSession(
+        id,
+        {
+          // Description saves use the last persisted session fields so an
+          // in-progress schedule/title edit is neither committed nor able to
+          // block the description update with an unrelated validation error.
+          title: session?.title ?? title.trim(),
+          startsAt: session?.startsAt ?? (startsAtDate ? startsAtDate.toISOString() : ''),
+          endsAt: session?.endsAt ?? (endsAtDate ? endsAtDate.toISOString() : ''),
+          registrationUrl: session?.registrationUrl ?? null,
+          description: nextDescription,
+        },
+        token,
+      )
+      setDescription(updated.description)
+      setSession((currentSession) => (currentSession ? { ...currentSession, ...updated } : updated))
+    } catch (err) {
+      setDescriptionError(err instanceof Error ? err.message : 'Failed to update session description')
+      throw err
+    } finally {
+      setDescriptionSaving(false)
+    }
+  }
+
   const [saveLoading, setSaveLoading] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
@@ -118,6 +165,7 @@ export default function SessionDetailPage() {
           startsAt: startsAtDate ? startsAtDate.toISOString() : '',
           endsAt: endsAtDate ? endsAtDate.toISOString() : '',
           registrationUrl,
+          description,
         },
         token,
       )
@@ -146,7 +194,7 @@ export default function SessionDetailPage() {
     }
   }
 
-  const busy = saveLoading || deleteLoading || titleSaveLoading
+  const busy = saveLoading || deleteLoading || titleSaveLoading || descriptionSaving
 
   if (loadingData) {
     return (
@@ -239,6 +287,7 @@ export default function SessionDetailPage() {
 
       {deleteError && <ErrorBanner message={deleteError} />}
       {titleSaveError && <ErrorBanner message={titleSaveError} />}
+      {descriptionError && <ErrorBanner message={descriptionError} />}
       {saveError && <ErrorBanner message={saveError} />}
 
       {saveLoading && (
@@ -249,6 +298,14 @@ export default function SessionDetailPage() {
           </div>
         </div>
       )}
+
+      <SessionDescription
+        value={description}
+        canEdit={canEditDescription}
+        onSave={handleDescriptionSave}
+        saving={descriptionSaving}
+        disabled={busy}
+      />
 
       <form onSubmit={handleSave} noValidate className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-6">

--- a/src/frontend/components/series-details-editor.tsx
+++ b/src/frontend/components/series-details-editor.tsx
@@ -14,6 +14,19 @@ export interface SeriesDetailsEditorProps {
   onCancel: () => void
   disabled?: boolean
   saving?: boolean
+  /**
+   * Accessible label for the formatting toolbar. Defaults to the series-details
+   * wording; callers reusing this editor for a different field (e.g. the
+   * session description, specs/003-session-description) should pass a
+   * distinct label so the two fields remain unambiguous to assistive tech.
+   */
+  toolbarLabel?: string
+  /** Accessible name for the editable region. Defaults to "Series details". */
+  textboxLabel?: string
+  /** Placeholder copy shown when the editable region is empty. */
+  placeholderText?: string
+  /** Label for the primary save button. Defaults to "Save details". */
+  saveLabel?: string
 }
 
 type FormatCommand = 'bold' | 'italic' | 'underline' | 'insertUnorderedList'
@@ -26,6 +39,10 @@ type FormatCommand = 'bold' | 'italic' | 'underline' | 'insertUnorderedList'
  * the repository's approved stack has no editor library, and the server
  * (`SeriesDetailsSanitizer`) remains the sole authority for the persisted
  * markup regardless of what the browser produces here.
+ *
+ * Reused (unchanged behavior/defaults) by the session description feature
+ * (specs/003-session-description/research.md Decision 4) via the optional
+ * label/placeholder props below.
  */
 export function SeriesDetailsEditor({
   initialValue,
@@ -33,6 +50,10 @@ export function SeriesDetailsEditor({
   onCancel,
   disabled = false,
   saving = false,
+  toolbarLabel = 'Series details formatting',
+  textboxLabel = 'Series details',
+  placeholderText = 'Describe the series and what attendees can expect\u2026',
+  saveLabel = 'Save details',
 }: SeriesDetailsEditorProps) {
   const editorRef = useRef<HTMLDivElement | null>(null)
   const [isEmpty, setIsEmpty] = useState(() => initialValue.trim().length === 0)
@@ -126,7 +147,7 @@ export function SeriesDetailsEditor({
     <div className="space-y-2">
       <div
         role="toolbar"
-        aria-label="Series details formatting"
+        aria-label={toolbarLabel}
         className="flex items-center gap-1 rounded-t-lg px-2 py-1"
         style={{
           border: '1px solid var(--borderColor-default)',
@@ -193,14 +214,14 @@ export function SeriesDetailsEditor({
             style={{ color: 'var(--fgColor-muted)' }}
             aria-hidden="true"
           >
-            Describe the series and what attendees can expect&hellip;
+            {placeholderText}
           </p>
         )}
         <div
           ref={editorRef}
           role="textbox"
           aria-multiline="true"
-          aria-label="Series details"
+          aria-label={textboxLabel}
           contentEditable={!controlsDisabled}
           suppressContentEditableWarning
           onInput={handleInput}
@@ -225,7 +246,7 @@ export function SeriesDetailsEditor({
           disabled={controlsDisabled}
           aria-busy={saving}
         >
-          {saving ? <Spinner size="small" /> : 'Save details'}
+          {saving ? <Spinner size="small" /> : saveLabel}
         </Button>
         <Button variant="default" size="small" onClick={onCancel} disabled={saving}>
           Cancel

--- a/src/frontend/components/session-description.tsx
+++ b/src/frontend/components/session-description.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useEffect, useId, useRef, useState } from 'react'
+import { PencilIcon, PlusIcon } from '@primer/octicons-react'
+import { Button, IconButton } from '@primer/react'
+import { SeriesDetailsEditor } from '@/components/series-details-editor'
+import { hasSeriesDetails, renderSeriesDetailsHtml } from '@/lib/series-details-html'
+
+export interface SessionDescriptionProps {
+  /** Sanitized session description HTML from the server, or `null` when none is saved. */
+  value: string | null
+  /**
+   * Whether the current user may add/edit the description. Mirrors
+   * `SeriesDetailsProps.canEdit` (see series-details.tsx): the backend's
+   * GET/PUT `/api/v1/sessions/{id}` endpoints are owner-scoped only (see
+   * specs/003-session-description/contracts/session-description-api.md) --
+   * there is no distinct non-owner "viewer" role today, so anyone who can
+   * load this page can also edit it. Threaded through explicitly so a future
+   * access model only needs to change the single call site that computes it.
+   */
+  canEdit: boolean
+  onSave: (nextValue: string) => Promise<void>
+  saving?: boolean
+  disabled?: boolean
+}
+
+/**
+ * Collapsed height bound (roughly six-to-eight lines at this component's
+ * text-sm/leading-relaxed sizing) so a long description never pushes
+ * schedule, registration, or metrics off the viewport by default (FR-010).
+ * See specs/003-session-description/research.md Decision 5.
+ */
+const COLLAPSED_MAX_HEIGHT_PX = 176
+
+/**
+ * Session Description section: sanitized read-only rendering for any viewer,
+ * an accessible add/edit affordance and headless editor reused from Series
+ * Details for owners, and a bounded collapsed presentation with
+ * keyboard-operable "Show more…"/"Show less…" disclosure controls for long
+ * content (FR-010/FR-011). Read-only, non-editing users never see an empty
+ * "Add description" prompt when no description exists (mirrors
+ * series-details.tsx's FR-008-equivalent behavior).
+ *
+ * Reuses `SeriesDetailsEditor` and the safe `renderSeriesDetailsHtml`
+ * renderer with session-specific labels (specs/003-session-description/
+ * research.md Decisions 4-5) so a session description is never visually or
+ * programmatically confused with a series description (SC-003).
+ */
+export function SessionDescription({
+  value,
+  canEdit,
+  onSave,
+  saving = false,
+  disabled = false,
+}: SessionDescriptionProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const contentId = useId()
+  const hasDescription = hasSeriesDetails(value)
+
+  // A newly saved/reloaded value always starts in the bounded collapsed state.
+  // Adjusted during render (not in an effect) per the React-recommended
+  // "adjusting state when a prop changes" pattern, avoiding an extra
+  // cascading render from a setState-in-effect.
+  const [prevValue, setPrevValue] = useState(value)
+  if (value !== prevValue) {
+    setPrevValue(value)
+    setIsExpanded(false)
+  }
+
+  // Resize-safe overflow measurement: only render the disclosure control when
+  // the collapsed content actually overflows its bound. Re-measures on
+  // viewport/content resizes while collapsed; once expanded there is no
+  // clamp to overflow, so measurement pauses until collapsed again.
+  useEffect(() => {
+    if (!hasDescription || isEditing || isExpanded) return
+
+    const node = contentRef.current
+    if (!node) return
+
+    function measure() {
+      if (!node) return
+      setIsOverflowing(node.scrollHeight - node.clientHeight > 1)
+    }
+
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measure)
+      return () => window.removeEventListener('resize', measure)
+    }
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasDescription, isEditing, isExpanded, value])
+
+  if (!canEdit && !hasDescription) {
+    return null
+  }
+
+  async function handleEditorSave(nextValueHtml: string) {
+    try {
+      await onSave(nextValueHtml)
+      setIsEditing(false)
+    } catch {
+      // The parent page (app/sessions/[id]/page.tsx) surfaces the failure via
+      // an error banner and keeps `saving` false; staying in edit mode here
+      // retains the in-progress draft rather than discarding it.
+    }
+  }
+
+  return (
+    <section aria-label="Session description">
+      <div className="mb-3 flex items-center justify-between">
+        <h2
+          className="text-sm font-semibold uppercase tracking-wide"
+          style={{ color: 'var(--fgColor-muted)' }}
+        >
+          Description
+        </h2>
+        {canEdit && !isEditing && hasDescription && (
+          <IconButton
+            icon={PencilIcon}
+            aria-label="Edit session description"
+            variant="invisible"
+            size="small"
+            disabled={disabled}
+            onClick={() => setIsEditing(true)}
+          />
+        )}
+      </div>
+
+      {isEditing ? (
+        <SeriesDetailsEditor
+          initialValue={value ?? ''}
+          onSave={handleEditorSave}
+          onCancel={() => setIsEditing(false)}
+          disabled={disabled}
+          saving={saving}
+          toolbarLabel="Session description formatting"
+          textboxLabel="Session description"
+          placeholderText="Describe what attendees can expect in this session…"
+          saveLabel="Save description"
+        />
+      ) : hasDescription ? (
+        <div>
+          <div
+            id={contentId}
+            ref={contentRef}
+            className="max-w-none text-sm leading-relaxed [&_ul]:list-disc [&_ul]:pl-5 [&_p]:mb-2 [&_p:last-child]:mb-0 [&_li]:mb-1"
+            style={isExpanded ? undefined : { maxHeight: COLLAPSED_MAX_HEIGHT_PX, overflow: 'hidden' }}
+          >
+            {renderSeriesDetailsHtml(value as string)}
+          </div>
+          {isOverflowing && (
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              aria-controls={contentId}
+              onClick={() => setIsExpanded((expanded) => !expanded)}
+              className="mt-2 rounded text-sm font-medium underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              style={{ color: 'var(--fgColor-accent)' }}
+            >
+              {isExpanded ? 'Show less\u2026 session description' : 'Show more\u2026 session description'}
+            </button>
+          )}
+        </div>
+      ) : (
+        <Button
+          variant="invisible"
+          size="small"
+          leadingVisual={PlusIcon}
+          disabled={disabled}
+          onClick={() => setIsEditing(true)}
+          className="px-0"
+        >
+          Add description
+        </Button>
+      )}
+    </section>
+  )
+}

--- a/src/frontend/e2e/session-description.spec.ts
+++ b/src/frontend/e2e/session-description.spec.ts
@@ -1,0 +1,449 @@
+/**
+ * E2E tests for the Session Description rich-text field on the session
+ * detail page (specs/003-session-description).
+ *
+ * ── Auth strategy ────────────────────────────────────────────────────────────
+ * Same next-auth v4 session-token cookie injection approach as
+ * `series-details.spec.ts` / `session-registration-link.spec.ts`.
+ *
+ * ── Backend mocking strategy ─────────────────────────────────────────────────
+ * The session detail page (`/sessions/[id]`) is fully client-rendered
+ * ('use client'), so every backend call happens as a browser fetch that
+ * `page.route()` can intercept directly (unlike the series detail page's
+ * initial server-side fetch -- see series-export.spec.ts for that
+ * distinction).
+ *
+ * ── Owner-only access model (research.md Decision 4, mirrored from
+ * specs/001-series-details) ──
+ * The backend's GET/PUT /api/v1/sessions/{id} endpoints are owner-scoped
+ * only: there is no distinct "viewer" (non-owner) role today, so every
+ * request that can load this page also has edit rights.
+ */
+import { test, expect, type BrowserContext, type Page } from '@playwright/test'
+import { encode } from 'next-auth/jwt'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const NEXTAUTH_SECRET = 'NFB3bPhTe11U9QEm+GQ72rjQ63e2Zhkn0dsC4lsWvq8='
+const SERIES_ID = 'e2e-test-series-for-description-001'
+const SESSION_ID = 'e2e-test-session-description-001'
+const SESSION_ID_B = 'e2e-test-session-description-002'
+
+// A single very long paragraph, comfortably long enough to overflow the
+// component's bounded collapsed height regardless of exact container width.
+const LONG_DESCRIPTION_TEXT = Array.from(
+  { length: 40 },
+  (_, i) => `This is sentence number ${i + 1} describing what attendees can expect in this session.`,
+).join(' ')
+const LONG_DESCRIPTION_HTML = `<p>${LONG_DESCRIPTION_TEXT}</p>`
+
+// ── Mock fixtures ─────────────────────────────────────────────────────────────
+
+function buildMockSession(
+  sessionId: string,
+  description: string | null,
+  overrides: Partial<{ title: string; registrationUrl: string | null }> = {},
+) {
+  return {
+    sessionId,
+    seriesId: SERIES_ID,
+    title: overrides.title ?? 'E2E Description Test Session',
+    startsAt: '2026-09-01T17:00:00.000Z',
+    endsAt: '2026-09-01T18:00:00.000Z',
+    registrationUrl: overrides.registrationUrl ?? null,
+    description,
+  }
+}
+
+// ── Auth helper ───────────────────────────────────────────────────────────────
+
+async function injectSessionCookie(context: BrowserContext): Promise<void> {
+  const sessionToken = await encode({
+    token: {
+      name: 'E2E Test User',
+      email: 'e2e-test@example.com',
+      sub: 'e2e-test-user-id',
+      accessToken: 'e2e-test-access-token',
+    },
+    secret: NEXTAUTH_SECRET,
+  })
+
+  await context.addCookies([
+    {
+      name: 'next-auth.session-token',
+      value: sessionToken,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+// ── Route stubbing helper ────────────────────────────────────────────────────
+
+interface StubOptions {
+  sessionId?: string
+  initialDescription: string | null
+  /** Override the PUT response status/body for a specific test (save-failure, validation). */
+  putResponse?: { status: number; json?: unknown }
+  /** Delay (ms) before fulfilling PUT, to observe an in-flight saving state. */
+  putDelayMs?: number
+}
+
+async function stubSessionRoutes(page: Page, options: StubOptions) {
+  const sessionId = options.sessionId ?? SESSION_ID
+  let currentDescription = options.initialDescription
+
+  await page.route(`**/api/v1/sessions/${sessionId}`, async (route) => {
+    const method = route.request().method()
+    if (method === 'GET') {
+      await route.fulfill({ status: 200, json: buildMockSession(sessionId, currentDescription) })
+      return
+    }
+    if (method === 'PUT') {
+      if (options.putDelayMs) {
+        await new Promise((resolve) => setTimeout(resolve, options.putDelayMs))
+      }
+      if (options.putResponse) {
+        await route.fulfill({
+          status: options.putResponse.status,
+          json: options.putResponse.json ?? {
+            errorCode: 'validation_error',
+            message: 'Save failed',
+            correlationId: 'test-correlation-id',
+          },
+        })
+        return
+      }
+      const body = route.request().postDataJSON() as { title: string; description?: string | null }
+      // Mirror the server's plain-text normalization (data-model.md rule 3):
+      // markup-only content with no decoded text (e.g. a lone "<p><br></p>"
+      // left behind by clearing a contentEditable region) saves as null.
+      const rawDescription = body.description ?? null
+      const plainText = rawDescription ? rawDescription.replace(/<[^>]*>/g, '').trim() : ''
+      currentDescription = plainText.length > 0 ? rawDescription : null
+      await route.fulfill({
+        status: 200,
+        json: buildMockSession(sessionId, currentDescription, { title: body.title }),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.route(`**/api/v1/sessions/${sessionId}/metrics`, (route) =>
+    route.fulfill({ status: 404 }),
+  )
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+test.describe('Session detail page — Session Description field', () => {
+  test.beforeEach(async ({ context }) => {
+    await injectSessionCookie(context)
+  })
+
+  // ── User Story 2: empty/null description ──────────────────────────────────
+
+  test('shows an "Add description" affordance when no description is saved', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: null })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await expect(page.getByRole('button', { name: 'Add description' })).toBeVisible()
+  })
+
+  test('a legacy session with a null description remains coherent and usable', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: null })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    // No required-description warning, and the rest of the page (schedule,
+    // registration, Save/Cancel) remains present and usable (FR-005, SC-002).
+    await expect(page.getByText(/description is required/i)).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Schedule' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Registration' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+  })
+
+  // ── User Story 1: view formatted/populated description ─────────────────────
+
+  test('typing and formatting content, then saving, persists and re-renders read-only content', async ({
+    page,
+  }) => {
+    await stubSessionRoutes(page, { initialDescription: null })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Add description' }).click()
+
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await expect(editor).toBeVisible()
+    await editor.click()
+    await page.keyboard.type('Important session agenda')
+
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.getByRole('button', { name: 'Bold' }).click()
+
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect(page.getByRole('textbox', { name: 'Session description' })).toHaveCount(0)
+    await expect(page.getByText('Important session agenda')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit session description' })).toBeVisible()
+  })
+
+  test('reloading the page preserves previously saved description', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: '<p><strong>Persisted</strong> description</p>' })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await expect(page.getByText('Persisted description')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add description' })).toHaveCount(0)
+
+    await page.reload()
+
+    await expect(page.getByText('Persisted description')).toBeVisible()
+  })
+
+  test('two different sessions never display one another\'s description', async ({ page }) => {
+    await stubSessionRoutes(page, {
+      sessionId: SESSION_ID,
+      initialDescription: '<p>Session A description</p>',
+    })
+    await stubSessionRoutes(page, {
+      sessionId: SESSION_ID_B,
+      initialDescription: '<p>Session B description</p>',
+    })
+
+    await page.goto(`/sessions/${SESSION_ID}`)
+    await expect(page.getByText('Session A description')).toBeVisible()
+    await expect(page.getByText('Session B description')).toHaveCount(0)
+
+    await page.goto(`/sessions/${SESSION_ID_B}`)
+    await expect(page.getByText('Session B description')).toBeVisible()
+    await expect(page.getByText('Session A description')).toHaveCount(0)
+  })
+
+  // ── User Story 3: edit/save/cancel/clear lifecycle ──────────────────────────
+
+  test('canceling an edit discards draft changes and keeps the prior saved value', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: '<p>Original description</p>' })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Edit session description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type('Discarded draft')
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    await expect(page.getByRole('textbox', { name: 'Session description' })).toHaveCount(0)
+    await expect(page.getByText('Original description')).toBeVisible()
+    await expect(page.getByText('Discarded draft')).toHaveCount(0)
+  })
+
+  test('editing existing description and saving replaces the read-only content', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: '<p>Original description</p>' })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Edit session description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type('Updated description content')
+
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect(page.getByRole('textbox', { name: 'Session description' })).toHaveCount(0)
+    await expect(page.getByText('Updated description content')).toBeVisible()
+    await expect(page.getByText('Original description')).toHaveCount(0)
+  })
+
+  test('clearing all content and saving returns to the empty "Add description" state', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: '<p>Original description</p>' })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Edit session description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.press('Delete')
+
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect(page.getByRole('textbox', { name: 'Session description' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Add description' })).toBeVisible()
+    await expect(page.getByText('Original description')).toHaveCount(0)
+  })
+
+  test('shows a saving/disabled state while the description save is pending', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: null, putDelayMs: 300 })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Add description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.type('Slow save draft')
+
+    const saveButton = page.getByRole('button', { name: 'Save description' })
+    await saveButton.click()
+
+    // The button's accessible name changes once saving (its text is replaced
+    // by a spinner), so re-locate it by the always-present `aria-busy`
+    // attribute rather than by its (now-stale) name.
+    await expect(page.locator('button[aria-busy="true"]')).toBeVisible()
+    await expect(editor).toHaveAttribute('contenteditable', 'false')
+  })
+
+  test('a save failure keeps the editor open with the draft intact and shows an error banner', async ({
+    page,
+  }) => {
+    await stubSessionRoutes(page, {
+      initialDescription: null,
+      putResponse: {
+        status: 500,
+        json: {
+          errorCode: 'internal_error',
+          message: 'Failed to update session description',
+          correlationId: 'test-correlation-id',
+        },
+      },
+    })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Add description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.type('Draft that fails to save')
+
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect(page.getByText(/Failed to update session description/)).toBeVisible()
+    await expect(editor).toBeVisible()
+    await expect(editor).toContainText('Draft that fails to save')
+  })
+
+  test('an over-limit save shows the validation error returned by the API', async ({ page }) => {
+    await stubSessionRoutes(page, {
+      initialDescription: null,
+      putResponse: {
+        status: 400,
+        json: {
+          errorCode: 'validation_error',
+          message: 'Session description must not exceed 10,000 characters.',
+          correlationId: 'test-correlation-id',
+        },
+      },
+    })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Add description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.type('Some content that the stubbed API will reject as over-limit')
+
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect(page.getByText(/10,000 characters/)).toBeVisible()
+    await expect(editor).toBeVisible()
+  })
+
+  test('saving the description carries the currently loaded schedule and registration fields', async ({
+    page,
+  }) => {
+    const captured: { putBody: Record<string, unknown> | null } = { putBody: null }
+
+    await page.route(`**/api/v1/sessions/${SESSION_ID}`, async (route) => {
+      const method = route.request().method()
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          json: buildMockSession(SESSION_ID, null, {
+            registrationUrl: 'https://teams.microsoft.com/registration/example',
+          }),
+        })
+        return
+      }
+      if (method === 'PUT') {
+        captured.putBody = route.request().postDataJSON()
+        await route.fulfill({
+          status: 200,
+          json: buildMockSession(SESSION_ID, (captured.putBody?.description as string | null) ?? null, {
+            registrationUrl: 'https://teams.microsoft.com/registration/example',
+          }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.route(`**/api/v1/sessions/${SESSION_ID}/metrics`, (route) =>
+      route.fulfill({ status: 404 }),
+    )
+
+    await page.goto(`/sessions/${SESSION_ID}`)
+    await page.getByRole('button', { name: 'Add description' }).click()
+    const editor = page.getByRole('textbox', { name: 'Session description' })
+    await editor.click()
+    await page.keyboard.type('New description')
+    await page.getByRole('button', { name: 'Save description' }).click()
+
+    await expect.poll(() => captured.putBody?.registrationUrl).toBe(
+      'https://teams.microsoft.com/registration/example',
+    )
+    expect(captured.putBody?.title).toBe('E2E Description Test Session')
+  })
+
+  // ── User Story 1: bounded disclosure for long descriptions ─────────────────
+
+  test('a long description is bounded by default with an accessible "Show more…" control', async ({
+    page,
+  }) => {
+    await stubSessionRoutes(page, { initialDescription: LONG_DESCRIPTION_HTML })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    const showMore = page.getByRole('button', { name: 'Show more… session description' })
+    await expect(showMore).toBeVisible()
+    await expect(showMore).toHaveAttribute('aria-expanded', 'false')
+
+    const expandedId = await showMore.getAttribute('aria-controls')
+    expect(expandedId).toBeTruthy()
+
+    // Other session capabilities remain reachable even with a long description.
+    await expect(page.getByRole('heading', { name: 'Schedule' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+  })
+
+  test('activating "Show more…" expands the description and exposes "Show less…"', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: LONG_DESCRIPTION_HTML })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    const showMore = page.getByRole('button', { name: 'Show more… session description' })
+    await showMore.focus()
+    await showMore.press('Enter')
+
+    const showLess = page.getByRole('button', { name: 'Show less… session description' })
+    await expect(showLess).toBeVisible()
+    await expect(showLess).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByText('This is sentence number 40')).toBeVisible()
+  })
+
+  test('activating "Show less…" re-collapses the description', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: LONG_DESCRIPTION_HTML })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await page.getByRole('button', { name: 'Show more… session description' }).click()
+    const showLess = page.getByRole('button', { name: 'Show less… session description' })
+    await showLess.focus()
+    await showLess.press('Enter')
+
+    await expect(page.getByRole('button', { name: 'Show more… session description' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Show less… session description' })).toHaveCount(0)
+  })
+
+  test('a short description does not show a disclosure control', async ({ page }) => {
+    await stubSessionRoutes(page, { initialDescription: '<p>Short description</p>' })
+    await page.goto(`/sessions/${SESSION_ID}`)
+
+    await expect(page.getByText('Short description')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Show more/ })).toHaveCount(0)
+  })
+})

--- a/src/frontend/e2e/session-description.spec.ts
+++ b/src/frontend/e2e/session-description.spec.ts
@@ -122,7 +122,9 @@ async function stubSessionRoutes(page: Page, options: StubOptions) {
       // markup-only content with no decoded text (e.g. a lone "<p><br></p>"
       // left behind by clearing a contentEditable region) saves as null.
       const rawDescription = body.description ?? null
-      const plainText = rawDescription ? rawDescription.replace(/<[^>]*>/g, '').trim() : ''
+      const plainText = rawDescription
+        ? (new DOMParser().parseFromString(rawDescription, 'text/html').body.textContent ?? '').trim()
+        : ''
       currentDescription = plainText.length > 0 ? rawDescription : null
       await route.fulfill({
         status: 200,

--- a/src/frontend/lib/api/sessions.ts
+++ b/src/frontend/lib/api/sessions.ts
@@ -10,7 +10,13 @@ export async function getSessionsBySeries(
 
 export async function createSession(
   seriesId: string,
-  data: { title: string; startsAt: string; endsAt: string; registrationUrl?: string | null },
+  data: {
+    title: string
+    startsAt: string
+    endsAt: string
+    registrationUrl?: string | null
+    description?: string | null
+  },
   accessToken: string,
 ): Promise<SessionResponse> {
   return apiFetch<SessionResponse>(
@@ -29,7 +35,13 @@ export async function getSessionById(id: string, accessToken: string): Promise<S
 
 export async function updateSession(
   id: string,
-  data: { title: string; startsAt: string; endsAt: string; registrationUrl?: string | null },
+  data: {
+    title: string
+    startsAt: string
+    endsAt: string
+    registrationUrl?: string | null
+    description?: string | null
+  },
   accessToken: string,
 ): Promise<SessionResponse> {
   return apiFetch<SessionResponse>(

--- a/src/frontend/lib/api/types.ts
+++ b/src/frontend/lib/api/types.ts
@@ -35,6 +35,7 @@ export interface SessionResponse {
   startsAt: string
   endsAt: string
   registrationUrl: string | null
+  description: string | null
 }
 
 export interface SeriesMetricsResponse {

--- a/tests/backend/EnableFront.Builder.Api.Tests/Features/Sessions/SessionServiceTests.cs
+++ b/tests/backend/EnableFront.Builder.Api.Tests/Features/Sessions/SessionServiceTests.cs
@@ -687,6 +687,292 @@ public class SessionServiceTests : IDisposable
     }
 
 
+
+    // ---------- Description: sanitized persistence (specs/003-session-description) ----------
+
+    [Fact]
+    public async Task CreateAsync_SanitizesDescription_BeforePersisting()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var startsAt = DateTime.UtcNow.AddHours(1);
+        var req = new CreateSessionRequest(
+            "Described Session", startsAt, startsAt.AddHours(1),
+            RegistrationUrl: null,
+            Description: "<p><b>Bold</b> outcome</p><a href=\"https://example.com\">link text</a>");
+
+        // Act
+        var (session, errorCode) = await _sut.CreateAsync(series.SeriesId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        session!.Description.Should().Be("<p><strong>Bold</strong> outcome</p>link text");
+
+        var saved = await _db.Sessions.FindAsync(session.SessionId);
+        saved!.Description.Should().Be("<p><strong>Bold</strong> outcome</p>link text");
+    }
+
+    [Fact]
+    public async Task CreateAsync_LeavesDescriptionNull_WhenOmitted()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var startsAt = DateTime.UtcNow.AddHours(1);
+        var req = new CreateSessionRequest("No Description Session", startsAt, startsAt.AddHours(1));
+
+        // Act
+        var (session, errorCode) = await _sut.CreateAsync(series.SeriesId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        session!.Description.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<p></p>")]
+    public async Task CreateAsync_TreatsBlankOrWhitespaceOnlyDescription_AsNull(string blankDescription)
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var startsAt = DateTime.UtcNow.AddHours(1);
+        var req = new CreateSessionRequest(
+            "Blank Description Session", startsAt, startsAt.AddHours(1),
+            RegistrationUrl: null, Description: blankDescription);
+
+        // Act
+        var (session, errorCode) = await _sut.CreateAsync(series.SeriesId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        session!.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_Accepts_ExactlyMaxLengthDescription()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var text = new string('a', EnableFront.Builder.Common.SeriesDetailsSanitizer.MaxPlainTextLength);
+        var startsAt = DateTime.UtcNow.AddHours(1);
+        var req = new CreateSessionRequest(
+            "Max Length Description Session", startsAt, startsAt.AddHours(1),
+            RegistrationUrl: null, Description: text);
+
+        // Act
+        var (session, errorCode) = await _sut.CreateAsync(series.SeriesId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        session!.Description.Should().Be(text);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Rejects_OneOverMaxLengthDescription_AndPersistsNothing()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var text = new string('a', EnableFront.Builder.Common.SeriesDetailsSanitizer.MaxPlainTextLength + 1);
+        var startsAt = DateTime.UtcNow.AddHours(1);
+        var req = new CreateSessionRequest(
+            "Too Long Description Session", startsAt, startsAt.AddHours(1),
+            RegistrationUrl: null, Description: text);
+
+        // Act
+        var (session, errorCode) = await _sut.CreateAsync(series.SeriesId, req, OwnerUserId);
+
+        // Assert
+        session.Should().BeNull();
+        errorCode.Should().Be("validation_error");
+        (await _db.Sessions.AnyAsync(s => s.Title == "Too Long Description Session")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SanitizesDescription_BeforePersisting()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var session = BuildSession(series.SeriesId);
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        var newStart = DateTime.UtcNow.AddDays(3);
+        var req = new UpdateSessionRequest(
+            "Title", newStart, newStart.AddHours(1),
+            RegistrationUrl: null, Description: "<ul><li>One</li><li><i>Two</i></li></ul>");
+
+        // Act
+        var (result, errorCode) = await _sut.UpdateAsync(session.SessionId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        result!.Description.Should().Be("<ul><li>One</li><li><em>Two</em></li></ul>");
+
+        var saved = await _db.Sessions.FindAsync(session.SessionId);
+        saved!.Description.Should().Be("<ul><li>One</li><li><em>Two</em></li></ul>");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<p></p>")]
+    public async Task UpdateAsync_ClearsDescription_ToNull_WhenBlankOrWhitespaceProvided(string blankDescription)
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var session = BuildSession(series.SeriesId);
+        session.Description = "<p>Existing description</p>";
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        var newStart = DateTime.UtcNow.AddDays(3);
+        var req = new UpdateSessionRequest(
+            "Title", newStart, newStart.AddHours(1),
+            RegistrationUrl: null, Description: blankDescription);
+
+        // Act
+        var (result, errorCode) = await _sut.UpdateAsync(session.SessionId, req, OwnerUserId);
+
+        // Assert
+        errorCode.Should().BeNull();
+        result!.Description.Should().BeNull();
+
+        var saved = await _db.Sessions.FindAsync(session.SessionId);
+        saved!.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Rejects_OneOverMaxLengthDescription_AndPersistsNoPartialUpdate()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var session = BuildSession(series.SeriesId);
+        session.Description = "<p>Original description</p>";
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        var text = new string('a', EnableFront.Builder.Common.SeriesDetailsSanitizer.MaxPlainTextLength + 1);
+        var newStart = DateTime.UtcNow.AddDays(3);
+        var req = new UpdateSessionRequest(
+            "Changed Title", newStart, newStart.AddHours(1),
+            RegistrationUrl: null, Description: text);
+
+        // Act
+        var (result, errorCode) = await _sut.UpdateAsync(session.SessionId, req, OwnerUserId);
+
+        // Assert
+        result.Should().BeNull();
+        errorCode.Should().Be("validation_error");
+
+        var saved = await _db.Sessions.FindAsync(session.SessionId);
+        saved!.Title.Should().Be("Test Session", "no partial update should be persisted when validation fails");
+        saved.Description.Should().Be("<p>Original description</p>");
+        saved.StartsAt.Should().NotBe(newStart, "the rejected schedule change must not be persisted either");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsError_ForWrongOwner_EvenWhenDescriptionProvided()
+    {
+        // Arrange — an attacker (wrong owner) cannot alter another owner's session description.
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var session = BuildSession(series.SeriesId);
+        session.Description = "<p>Owner's original description</p>";
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        var req = new UpdateSessionRequest(
+            "Hack", DateTime.UtcNow, DateTime.UtcNow.AddHours(1),
+            RegistrationUrl: null, Description: "<p>Hacked description</p>");
+
+        // Act
+        var (result, errorCode) = await _sut.UpdateAsync(session.SessionId, req, OtherUserId);
+
+        // Assert
+        result.Should().BeNull();
+        errorCode.Should().Be("session_not_found");
+
+        var saved = await _db.Sessions.FindAsync(session.SessionId);
+        saved!.Description.Should().Be("<p>Owner's original description</p>");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsSanitizedDescription_ForCorrectOwner()
+    {
+        // Arrange
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var session = BuildSession(series.SeriesId);
+        session.Description = "<p><strong>Already sanitized</strong></p>";
+        _db.Sessions.Add(session);
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByIdAsync(session.SessionId, OwnerUserId);
+
+        // Assert
+        result!.Description.Should().Be("<p><strong>Already sanitized</strong></p>");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNullDescription_ForLegacySessionCreatedBeforeFeature()
+    {
+        // Arrange — simulates a pre-existing row where Description was never set (defaults to null),
+        // proving backward compatibility for sessions created before this feature (FR-005/edge cases).
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var legacySession = BuildSession(series.SeriesId);
+        _db.Sessions.Add(legacySession);
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByIdAsync(legacySession.SessionId, OwnerUserId);
+
+        // Assert
+        result!.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TwoSessions_InSameSeries_NeverShareOrLeakEachOthersDescription()
+    {
+        // Arrange — FR-007: one session's description must never appear on a different session.
+        var series = BuildSeries();
+        _db.Series.Add(series);
+        var sessionA = BuildSession(series.SeriesId);
+        sessionA.Description = "<p>Session A description</p>";
+        var sessionB = BuildSession(series.SeriesId);
+        sessionB.Description = "<p>Session B description</p>";
+        _db.Sessions.AddRange(sessionA, sessionB);
+        await _db.SaveChangesAsync();
+
+        // Act
+        var resultA = await _sut.GetByIdAsync(sessionA.SessionId, OwnerUserId);
+        var resultB = await _sut.GetByIdAsync(sessionB.SessionId, OwnerUserId);
+
+        // Assert
+        resultA!.Description.Should().Be("<p>Session A description</p>");
+        resultB!.Description.Should().Be("<p>Session B description</p>");
+    }
+
     // ---------- Helpers ----------
 
     private EnableFront.Builder.Domain.Entities.Series BuildSeries(string? ownerOverride = null) =>


### PR DESCRIPTION
## Why

Session detail pages had no place to capture session-specific context. Series already support an optional rich text description, but that description belongs to the whole series, so there was no way to describe what makes an individual session different. This adds the same capability at the session level.

## Approach

Sessions get their own nullable `Description` that is persisted with the session, so the content follows the individual session rather than being inherited from its series. The field flows through the existing session create, detail, and full update contracts, so no new endpoint was added.

Server-side sanitization reuses the existing series allow-list sanitizer. Sanitization runs before the entity is mutated, empty output is normalized to `null`, and content over 10,000 decoded characters is rejected without a partial update. Owner filtering is unchanged.

On the frontend, a new `SessionDescription` component reuses the established safe renderer and editor primitives. Long descriptions render collapsed by default with accessible "Show more..." / "Show less..." disclosure controls, so a long description cannot push schedule, registration, and metrics content out of the viewport.

## Notes for reviewers

- The description save path intentionally sends the last persisted title, schedule, and registration values rather than current form state. Without this, saving a description would silently commit an in-progress schedule edit or fail on an unrelated validation error. This is the one non-obvious behavior in the diff and is worth a careful look.
- The migration is additive and reversible. Existing rows stay `NULL`, so pre-existing sessions need no data cleanup.
- List summaries, exports, search, and notifications were deliberately left out of scope.
- Spec Kit artifacts for this feature live under `specs/003-session-description/`.

## Validation

- Backend build passed
- Session backend tests: 57 passed
- Frontend lint and build passed
- Session description E2E tests: 16 passed