### PR TITLE
Public series landing page with visibility toggle, banner image, and expandable sessions

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-session-description"
+  "feature_directory": "specs/004-public-series-landing-page"
 }

--- a/specs/004-public-series-landing-page/.spec-context.json
+++ b/specs/004-public-series-landing-page/.spec-context.json
@@ -1,0 +1,407 @@
+{
+  "workflow": "speckit",
+  "specName": "Public Series Landing Page",
+  "branch": "kwkraus-series-landing-page-spec",
+  "currentStep": "implement",
+  "status": "implementing",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-24T21:32:27.549Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T21:47:13.210Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T21:50:18.015Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.967Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T015",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T016",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T017",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T018",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T019",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T020",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T021",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T022",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T023",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T024",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T025",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T026",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T027",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T028",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T029",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T030",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.968Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T031",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T032",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T033",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T034",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T035",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T036",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T037",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T038",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T039",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T040",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T041",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T042",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T043",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T044",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T045",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T046",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T047",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-24T22:07:44.969Z"
+    }
+  ],
+  "currentTask": "T048"
+}

--- a/specs/004-public-series-landing-page/checklists/requirements.md
+++ b/specs/004-public-series-landing-page/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Public Series Landing Page
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed on first pass. No spec updates required before `/speckit.clarify` or
+  `/speckit.plan`.

--- a/specs/004-public-series-landing-page/contracts/public-series-api.md
+++ b/specs/004-public-series-landing-page/contracts/public-series-api.md
@@ -21,28 +21,34 @@ No query parameters, no request body, no headers required.
 {
   "title": "Modern Web Fundamentals",
   "details": "<p>Learn the essentials of building <strong>modern</strong> web apps.</p><ul><li>Outcome one</li></ul>",
+  "imageUrl": "https://cdn.example.com/modern-web-fundamentals.png",
   "sessions": [
     {
       "sessionId": "b7e1c2a0-....",
       "title": "Session 1: Getting Started",
       "startsAt": "2026-09-10T17:00:00Z",
       "endsAt": "2026-09-10T18:00:00Z",
-      "registrationUrl": "https://teams.microsoft.com/registration/..."
+      "registrationUrl": "https://teams.microsoft.com/registration/...",
+      "description": "Set up the tools and build your first page."
     },
     {
       "sessionId": "d4f9a311-....",
       "title": "Session 2: Advanced Patterns",
       "startsAt": "2026-09-17T17:00:00Z",
       "endsAt": "2026-09-17T18:00:00Z",
-      "registrationUrl": null
+      "registrationUrl": null,
+      "description": null
     }
   ]
 }
 ```
 
 - `details` is `null`/omitted-equivalent when the series has no `Details`.
+- `imageUrl` is `null` when the series has no configured image URL.
 - `sessions` is `[]` when the series has zero sessions (frontend renders the empty-state message,
   FR-009).
+- `description` is `null` when a session has no description; otherwise it contains the session's
+  descriptive text.
 - `registrationUrl` is `null` for sessions with no stored registration URL (FR-006) — the frontend
   omits the Register control entirely for that row.
 - No `ownerUserId`, `seriesId`, `isPublic`, or metrics field is present anywhere in this shape

--- a/specs/004-public-series-landing-page/contracts/public-series-api.md
+++ b/specs/004-public-series-landing-page/contracts/public-series-api.md
@@ -52,9 +52,9 @@ No query parameters, no request body, no headers required.
 
 ```json
 {
-  "code": "series_not_found",
+  "errorCode": "series_not_found",
   "message": "Series not found.",
-  "traceId": "0HN..."
+  "correlationId": "0HN..."
 }
 ```
 

--- a/specs/004-public-series-landing-page/contracts/public-series-api.md
+++ b/specs/004-public-series-landing-page/contracts/public-series-api.md
@@ -1,0 +1,98 @@
+# API Contract: Public Series Landing Page
+
+## `GET /api/v1/public/series/{id}`
+
+Anonymous (no `Authorization` header required, no session cookie honored/required). New unauthenticated
+endpoint group, separate from the existing `/api/v1/series` authenticated group.
+
+### Request
+
+| Part | Field | Type | Notes |
+|---|---|---|---|
+| Path | `id` | `Guid` | The series' existing `SeriesId`, used verbatim as the obfuscated public identifier. |
+
+No query parameters, no request body, no headers required.
+
+### Responses
+
+#### `200 OK` — series exists and `IsPublic == true`
+
+```json
+{
+  "title": "Modern Web Fundamentals",
+  "details": "<p>Learn the essentials of building <strong>modern</strong> web apps.</p><ul><li>Outcome one</li></ul>",
+  "sessions": [
+    {
+      "sessionId": "b7e1c2a0-....",
+      "title": "Session 1: Getting Started",
+      "startsAt": "2026-09-10T17:00:00Z",
+      "endsAt": "2026-09-10T18:00:00Z",
+      "registrationUrl": "https://teams.microsoft.com/registration/..."
+    },
+    {
+      "sessionId": "d4f9a311-....",
+      "title": "Session 2: Advanced Patterns",
+      "startsAt": "2026-09-17T17:00:00Z",
+      "endsAt": "2026-09-17T18:00:00Z",
+      "registrationUrl": null
+    }
+  ]
+}
+```
+
+- `details` is `null`/omitted-equivalent when the series has no `Details`.
+- `sessions` is `[]` when the series has zero sessions (frontend renders the empty-state message,
+  FR-009).
+- `registrationUrl` is `null` for sessions with no stored registration URL (FR-006) — the frontend
+  omits the Register control entirely for that row.
+- No `ownerUserId`, `seriesId`, `isPublic`, or metrics field is present anywhere in this shape
+  (FR-007, SC-005).
+
+#### `404 Not Found` — series does not exist **or** `IsPublic == false`
+
+```json
+{
+  "code": "series_not_found",
+  "message": "Series not found.",
+  "traceId": "0HN..."
+}
+```
+
+Identical shape and content for both cases (FR-008, FR-016, SC-004) — the response MUST NOT reveal
+whether a matching series exists but is private.
+
+### Authorization
+
+None. This endpoint MUST NOT be added to the existing `MapGroup("/api/v1/series").RequireAuthorization()`
+group. It lives in its own `MapGroup("/api/v1/public/series")` with no `.RequireAuthorization()` call.
+
+---
+
+## `PUT /api/v1/series/{id}` (existing endpoint, extended)
+
+Existing authenticated endpoint. Request body gains one new optional field.
+
+### Request body (delta only)
+
+```json
+{
+  "title": "Modern Web Fundamentals",
+  "details": "<p>...</p>",
+  "isPublic": true
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `isPublic` | `bool` | yes (new) | When omitted by an older client, defaults to the series' current stored value (no silent reset to `false` on unrelated saves) — see `research.md` / `tasks.md` for the exact deserialization rule to implement. |
+
+### Response (delta only)
+
+`SeriesResponseDto` gains `isPublic: bool` so the admin UI can reflect current on/off state (FR-015).
+
+### Authorization
+
+Unchanged — existing `RequireAuthorization()` + ownership check (`OwnerUserId == callerUserId`)
+already enforced by `SeriesService.UpdateAsync`. A caller without edit permission on the series
+continues to receive the existing `404`/`401` behavior; they cannot view or change `isPublic` for a
+series they don't own (FR-015).

--- a/specs/004-public-series-landing-page/data-model.md
+++ b/specs/004-public-series-landing-page/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Public Series Landing Page
+
+## Series (updated)
+
+Existing aggregate in `src/backend/Domain/Entities/Series.cs`.
+
+| Field | Type | Required | Rules |
+|---|---|---:|---|
+| `SeriesId` | `Guid` | yes | Existing UUID primary key; doubles as the public landing page route key (`/public/series/{SeriesId}`) |
+| `OwnerUserId` | `string` | yes | Existing authorization boundary; unchanged, never returned by the public endpoint |
+| `Title` | `string` | yes | Existing non-empty title rule; returned by the public endpoint verbatim |
+| `Details` | `string?` | no | Existing sanitized constrained HTML; returned by the public endpoint verbatim when non-null, omitted when `null` |
+| `IsPublic` | `bool` | yes | **NEW.** Defaults to `false` for every new and existing series. Gates whether the public landing page (and its data) is reachable. Editable only by a user with existing series edit permission, via the same save pattern as `Title`/`Details`. |
+| `CreatedAt` | `DateTime` | yes | Unchanged |
+| `UpdatedAt` | `DateTime` | yes | Updated on successful `IsPublic` toggle, same as other field saves |
+
+### Storage mapping
+
+Add non-nullable `bit` column `IsPublic` to `Series` with default `0`/`false`. Existing rows backfill
+to `false` (no destructive migration; every pre-existing series remains private until an owner opts
+in). No index required — the column is not used for filtering/sorting, only as a per-row boolean gate
+checked on the single-row anonymous read.
+
+### Rules
+
+1. `IsPublic` defaults to `false` on `CreateAsync`; owners set it explicitly via `UpdateAsync`.
+2. Toggling `IsPublic` follows the same authorization boundary as other series fields — only the
+   `OwnerUserId` for that series (via existing `RequireAuthorization()` + ownership check in
+   `SeriesService`) may change it.
+3. Toggling takes effect immediately — no caching layer or propagation delay is introduced.
+4. The value has no effect on any other stored field or existing behavior; it purely gates the new
+   anonymous read path.
+
+## Session (read-only projection, no schema change)
+
+Existing aggregate in `src/backend/Domain/Entities/Session.cs`. No new fields are added to `Session`
+by this feature — the public endpoint projects existing fields into a new response shape.
+
+| Field (existing) | Exposed in public projection? | Notes |
+|---|---:|---|
+| `SessionId` | yes | Used as the table row key on the frontend; never used to construct a public route |
+| `SeriesId` | no (implicit via the parent series being requested) | Not repeated per-row in the response |
+| `OwnerUserId` | **no** | Owner-only; never exposed by the public endpoint |
+| `Title` | yes | Rendered as the session's row title |
+| `StartsAt` / `EndsAt` | yes | Rendered as the session's date/time; used to determine "already ended" for Register-control suppression (FR-013) |
+| `RegistrationUrl` | yes, when non-null | Renders the Register control; omitted entirely when `null` (existing behavior, FR-006) |
+| `Description` | out of scope for this feature | Spec does not require per-session description on the landing page table; not projected |
+
+### Public projection DTOs (new)
+
+- `PublicSeriesResponseDto(string Title, string? Details, IReadOnlyList<PublicSessionDto> Sessions)`
+- `PublicSessionDto(Guid SessionId, string Title, DateTime StartsAt, DateTime EndsAt, string? RegistrationUrl)`
+
+Neither DTO includes `SeriesId`, `OwnerUserId`, `IsPublic`, metrics, or any timestamp beyond session
+schedule — satisfying FR-007/SC-005 (no owner-only data in the public response).
+
+### Relationships and transitions
+
+`Series` (1) → `Session` (many), unchanged existing relationship. The only new transition is
+`Series.IsPublic`: `false → true` (owner publishes) and `true → false` (owner unpublishes), both via
+the existing series update save path. No new entity is introduced.

--- a/specs/004-public-series-landing-page/plan.md
+++ b/specs/004-public-series-landing-page/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Public Series Landing Page
+
+**Branch**: `004-public-series-landing-page` | **Date**: 2026-08-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-public-series-landing-page/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command; its definition describes the execution workflow.
+
+## Summary
+
+Add an owner-controlled, off-by-default `IsPublic` flag on `Series`, a new anonymous (no
+`RequireAuthorization`) backend endpoint that returns a series' title, sanitized details, and its
+sessions (title, schedule, registration URL) only when that flag is on — treating "off" identically to
+"not found" — and a new public Next.js route `app/public/series/[id]/page.tsx` that renders that data
+as a professional, responsive landing page with a session table and per-session Register links opening
+in a new tab. The existing admin series page gains a toggle control (permission-gated the same way
+title editing already is) to turn the flag on/off.
+
+## Technical Context
+
+**Language/Version**: C# (.NET 10) for backend; TypeScript / React 19 for frontend.
+
+**Primary Dependencies**: ASP.NET Core Minimal API, EF Core (Azure SQL), Microsoft.Identity.Web
+(existing auth) — new endpoint intentionally omits `RequireAuthorization`. Next.js 16 App Router,
+Tailwind CSS v4, Primer React v38 (existing design system, reused for the public page).
+
+**Storage**: Azure SQL via EF Core. One new nullable-free `bool IsPublic` column on the existing
+`Series` table, added via an EF Core migration, defaulting to `false`.
+
+**Testing**: xUnit for backend (endpoint + service tests: authorized owner toggles flag; anonymous GET
+respects flag on/off/not-found). Playwright E2E for the new public page (renders anonymously, session
+table, Register link behavior, responsive layout) plus existing frontend test patterns for the new
+admin toggle control.
+
+**Target Platform**: Existing Azure App Service–hosted backend API and Next.js frontend; public page is
+served by the same Next.js app under a new route, not a separate deployment.
+
+**Project Type**: Web application (existing `src/backend` + `src/frontend` split).
+
+**Performance Goals**: Public landing page data loads and renders within 3 seconds on typical broadband
+(SC-001) — satisfied by a single anonymous GET returning series + sessions in one round trip, no
+client-side waterfall.
+
+**Constraints**: Anonymous endpoint MUST NOT leak owner-only data (owner id, metrics, edit affordances)
+and MUST return the same generic not-found shape for "series does not exist" and "series exists but
+`IsPublic` is false" (FR-008, FR-016, SC-004, SC-005). No new auth model introduced (FR-002 caveat via
+FR-014-017). No rate limiting/caching layer introduced by this feature (per Assumptions).
+
+**Scale/Scope**: One new DB column + migration, one new anonymous backend endpoint (plus a toggle field
+on the existing update endpoint), one new public Next.js route + page component + session-table
+component, one new toggle control on the existing admin series page. No new services or external
+integrations.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Code Quality & Maintainability**: New public endpoint lives in the existing
+  `Features/Series` (and reads `Features/Sessions`-equivalent data) vertical slice; no new
+  cross-cutting abstraction is introduced beyond a small DTO/mapping reused from existing
+  `SeriesResponseDto`/session DTOs. PASS.
+- **II. Testing Standards & Regression Prevention**: Plan requires xUnit coverage for the anonymous
+  endpoint's on/off/not-found behavior and the owner-only toggle authorization, plus Playwright
+  coverage for the public page's anonymous rendering and responsive behavior. PASS (tests planned
+  before implementation per TDD conventions already used in this repo).
+- **III. UX Consistency & Accessibility**: Public page reuses existing Tailwind/Primer design tokens
+  and components rather than a new visual system (FR-011); empty/loading/not-found states are
+  explicitly designed (FR-008, FR-009). PASS.
+- **IV. Performance & Reliability**: Single anonymous GET satisfies SC-001; no N+1 query pattern (mirrors
+  existing `SeriesService.GetAllAsync` batching pattern for sessions). PASS.
+- **V. Security & Data Protection**: This is the one gate requiring explicit justification — the new
+  endpoint is intentionally unauthenticated. This is the entire point of the feature (public landing
+  page) and is scoped tightly: read-only, no owner identity, no metrics, gated by the explicit
+  off-by-default `IsPublic` flag that only a permitted owner can flip. Documented in Complexity
+  Tracking below per constitution's "Security exceptions MUST be documented, reviewed, and
+  time-bounded" rule (this exception is scope-bound rather than time-bound, since anonymous read is a
+  permanent, intended feature of this endpoint). PASS WITH DOCUMENTED EXCEPTION.
+- **VI. Operational Visibility**: Anonymous endpoint requests and owner toggle changes MUST be logged
+  (structured, no PII) so misuse or unexpected traffic patterns are diagnosable. PASS (planned as part
+  of endpoint implementation, consistent with existing endpoint logging conventions).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-public-series-landing-page/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/backend/
+├── Domain/Entities/
+│   └── Series.cs                          # + IsPublic bool property
+├── Features/Series/
+│   ├── SeriesEndpoints.cs                  # + PUT toggle support (existing UpdateSeriesRequest)
+│   ├── SeriesService.cs                    # + IsPublic persisted on update
+│   ├── Public/
+│   │   ├── PublicSeriesEndpoints.cs        # NEW: anonymous GET /api/v1/public/series/{id}
+│   │   ├── PublicSeriesService.cs          # NEW: reads Series+Sessions, enforces IsPublic gate
+│   │   └── Dtos/
+│   │       ├── PublicSeriesResponseDto.cs  # NEW: title, details, sessions[]
+│   │       └── PublicSessionDto.cs         # NEW: title, startsAt, endsAt, registrationUrl
+│   └── Dtos/
+│       ├── UpdateSeriesRequest.cs          # + IsPublic
+│       └── SeriesResponseDto.cs            # + IsPublic (admin view of current state)
+├── Migrations/
+│   └── {timestamp}_AddIsPublicToSeries.cs  # NEW EF Core migration
+└── Features/Series/SeriesEndpoints.cs      # existing group keeps RequireAuthorization();
+                                             # Public/ endpoints registered on a separate,
+                                             # unauthenticated MapGroup
+
+src/frontend/
+├── app/
+│   ├── series/[id]/page.tsx                # + IsPublic toggle control (admin view)
+│   └── public/series/[id]/
+│       ├── page.tsx                        # NEW: public landing page (server component)
+│       ├── not-found.tsx                   # NEW: generic not-found state
+│       └── loading.tsx                     # NEW: loading skeleton
+├── components/
+│   ├── series-visibility-toggle.tsx        # NEW: admin on/off control
+│   └── public-series-landing.tsx           # NEW: renders title/details/session table
+└── e2e/
+    └── public-series-landing.spec.ts       # NEW: Playwright coverage
+```
+
+**Structure Decision**: Existing web application split (`src/backend`, `src/frontend`) is retained. The
+public read path is isolated as a `Features/Series/Public` sub-slice on the backend (own DTOs/service,
+own unauthenticated `MapGroup`) so the authenticated `Features/Series` group's `RequireAuthorization()`
+is never accidentally weakened, and as a new `app/public/series/[id]` route tree on the frontend so the
+existing authenticated `app/series/[id]` admin page and its layout/providers are untouched.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New unauthenticated backend endpoint (violates default "V. Security & Data Protection" expectation that user/business endpoints enforce identity validation) | The feature's entire purpose (spec `FR-002`) is a page anonymous visitors can view without signing in; there is no way to deliver the specified user value with an authenticated-only endpoint. | Rejected: gating the existing authenticated `GET /api/v1/series/{id}` behind a share token would require inventing a new token/identity mechanism not requested in the spec and explicitly out of scope per the spec's Assumptions ("no new short-lived token... is introduced"). Risk is bounded by (a) the endpoint being read-only, (b) an explicit off-by-default `IsPublic` flag the owner must deliberately enable, and (c) the endpoint returning zero owner-only fields (no owner id, no metrics). |
+

--- a/specs/004-public-series-landing-page/quickstart.md
+++ b/specs/004-public-series-landing-page/quickstart.md
@@ -1,0 +1,64 @@
+# Public Series Landing Page Quickstart
+
+## Prerequisites
+
+- .NET 10 SDK and Node.js/npm installed.
+- Repository dependencies restored.
+- Configured backend database/test settings; no authenticated session is needed for the anonymous
+  E2E scenarios, but an authenticated local session is needed for the admin-toggle scenarios.
+
+## Backend validation
+
+From `src/backend`:
+
+```powershell
+dotnet build
+dotnet test ..\..\tests\backend\EnableFront.Builder.Api.Tests\EnableFront.Builder.Api.Tests.csproj
+```
+
+Verify tests cover:
+
+1. `GET /api/v1/public/series/{id}` returns `200` with title/details/sessions when `IsPublic == true`.
+2. The same endpoint returns `404` (identical `series_not_found` shape) when `IsPublic == false`.
+3. The same endpoint returns `404` (identical shape) when `id` does not match any series.
+4. The response never contains `ownerUserId`, `seriesId`, `isPublic`, or metrics fields.
+5. Sessions with no `RegistrationUrl` are present in `sessions[]` with `registrationUrl: null`.
+6. `PUT /api/v1/series/{id}` persists `isPublic` and returns it in `SeriesResponseDto`; a non-owner
+   caller cannot change it (existing ownership check).
+7. New series default `IsPublic` to `false`; apply the generated EF migration through the normal
+   deployment pipeline, not automatic startup migrations (existing project convention).
+
+## Frontend validation
+
+From `src/frontend`:
+
+```powershell
+npm run lint
+npm run build
+npm run test:e2e -- e2e/public-series-landing.spec.ts
+```
+
+Verify these user flows:
+
+1. **Anonymous view (P1)**: With no auth cookie set, navigating to `/public/series/{id}` for a public
+   series renders the title, formatted details, and a session table without any sign-in redirect.
+2. **Empty details**: A public series with no `Details` renders the page without an empty/broken
+   description section.
+3. **Empty sessions**: A public series with zero sessions shows the neutral "no sessions scheduled
+   yet" message instead of an empty table.
+4. **Not found parity**: Both a nonexistent `id` and a real-but-private (`IsPublic == false`) `id`
+   render the same generic not-found page.
+5. **Register control (P2)**: A session row with a `registrationUrl` shows a Register control that
+   opens the destination in a new tab; a row without one shows no control.
+6. **Ended session**: A session whose `EndsAt` is in the past appears in the table without an active
+   Register control, even if it has a `registrationUrl`.
+7. **Responsive layout (P3)**: At mobile (~375px), tablet (~768px), and desktop (~1280px+) viewport
+   widths, the session table reflows without horizontal overflow or clipped content.
+8. **Admin toggle**: An owner can see and flip the `IsPublic` toggle on the existing admin series page;
+   a non-owner cannot see or use it; toggling takes effect on the very next anonymous request.
+
+> **Known local/E2E consideration**: `app/public/series/[id]/page.tsx` is a Server Component fetching
+> from the backend on the Node side (same pattern as `app/series/[id]/page.tsx`, see
+> `specs/001-series-details/quickstart.md`). Scenarios requiring specific pre-seeded series/session
+> data on first load need a real or stubbed backend reachable at `BACKEND_API_BASE_URL` (default
+> `http://localhost:5187`); this is a pre-existing project constraint, not introduced by this feature.

--- a/specs/004-public-series-landing-page/research.md
+++ b/specs/004-public-series-landing-page/research.md
@@ -1,0 +1,75 @@
+# Phase 0 Research: Public Series Landing Page
+
+All items from the spec's Technical Context were resolvable directly from the existing codebase and
+constitution; no open NEEDS CLARIFICATION items remain.
+
+## Decision: Visibility gate is a boolean `IsPublic` column on `Series`
+
+- **Decision**: Add `public bool IsPublic { get; set; } = false;` to `Domain/Entities/Series.cs`,
+  default `false`, migrated via EF Core.
+- **Rationale**: Spec FR-014 requires an on/off setting defaulting to off; the simplest, most
+  maintainable representation consistent with existing `Series` fields (`Title`, `Details`) is a plain
+  boolean column, edited the same way `Title`/`Details` already are (via `PUT /api/v1/series/{id}`).
+- **Alternatives considered**: A separate `SeriesVisibility` table/entity — rejected as unnecessary
+  indirection for a single boolean with no history/audit requirement in the spec (YAGNI, per
+  Constitution I).
+
+## Decision: Anonymous read path is a separate, unauthenticated endpoint group
+
+- **Decision**: New `MapGroup("/api/v1/public/series")` (no `.RequireAuthorization()`) in a new
+  `Features/Series/Public/PublicSeriesEndpoints.cs`, distinct from the existing authenticated
+  `Features/Series/SeriesEndpoints.cs` group.
+- **Rationale**: Keeps the authenticated group's `RequireAuthorization()` simple and impossible to
+  accidentally weaken; isolates the security-sensitive anonymous surface into its own small, reviewable
+  file/service, matching the repo's existing "vertical feature slice" convention (e.g.,
+  `Features/Sessions`, `Features/Series`).
+- **Alternatives considered**: Adding an `[AllowAnonymous]`-equivalent override on the existing
+  `GET /api/v1/series/{id}` route — rejected because ASP.NET Core minimal API group-level
+  `RequireAuthorization()` makes per-route anonymous overrides easy to misconfigure and harder to audit
+  than a fully separate group with its own DTOs that guarantee no owner-only field can leak.
+
+## Decision: "Off" and "not found" return identical response shape
+
+- **Decision**: `PublicSeriesService.GetPublicSeriesAsync` returns `null` both when no series exists
+  for the id and when `series.IsPublic == false`; the endpoint always maps `null` to the same
+  `Results.NotFound(new ErrorEnvelope("series_not_found", ...))` shape already used by the existing
+  authenticated `GET /api/v1/series/{id}` for a missing series.
+- **Rationale**: Directly satisfies FR-008/FR-016/SC-004/SC-005 (no signal distinguishing "doesn't
+  exist" from "exists but private").
+- **Alternatives considered**: A distinct `403 Forbidden` for "exists but off" — rejected explicitly by
+  the spec (FR-016 requires the identical not-found response).
+
+## Decision: Public page is a new Next.js route tree, not a query param on the admin page
+
+- **Decision**: `app/public/series/[id]/page.tsx` (server component, fetches from the new anonymous
+  endpoint), with sibling `not-found.tsx` and `loading.tsx`.
+- **Rationale**: The existing authenticated `app/series/[id]/page.tsx` is wrapped by the app's
+  authenticated layout/providers (next-auth session, admin nav). A new route under `app/public/` keeps
+  the anonymous experience free of any accidental auth-gated layout wrapping and matches the existing
+  `app/login`/`app/about` pattern of top-level, purpose-specific route segments.
+- **Alternatives considered**: Reusing `app/series/[id]/page.tsx` with an anonymous-mode branch —
+  rejected because Next.js App Router layouts inherited from `app/series/` may assume an authenticated
+  session (e.g., `app-header.tsx`/`user-menu.tsx`), risking accidental exposure of admin chrome or
+  session-dependent calls on a page that must work with zero auth context.
+
+## Decision: Reuse existing rich-text rendering and design system
+
+- **Decision**: Render `Details` using the existing `lib/series-details-html.tsx` sanitized-HTML
+  rendering helper already used by `components/series-details.tsx`; style the new page with existing
+  Tailwind/Primer tokens.
+- **Rationale**: FR-003 requires the same formatting support already implemented; FR-011 requires
+  reusing the existing design system rather than inventing a new one. Directly satisfies Constitution
+  III (shared UI patterns reused, not ad hoc).
+- **Alternatives considered**: A new lightweight markdown renderer for the public page — rejected as
+  duplicate logic for content that is already sanitized/stored as the same HTML subset.
+
+## Decision: Session table responsiveness via existing Tailwind responsive utilities
+
+- **Decision**: Implement the session list as a table on wider viewports and a stacked card list below
+  a Tailwind `sm:`/`md:` breakpoint, using the same responsive utility approach already used elsewhere
+  in the frontend (Tailwind CSS v4 is already the approved stack).
+- **Rationale**: Satisfies FR-010/SC-003 without introducing a new UI library or custom breakpoint
+  system.
+- **Alternatives considered**: A third-party responsive table component — rejected; no new runtime
+  dependency is justified per constitution's "No new runtime dependency may be introduced without
+  explicit product and review justification."

--- a/specs/004-public-series-landing-page/spec.md
+++ b/specs/004-public-series-landing-page/spec.md
@@ -1,0 +1,283 @@
+# Feature Specification: Public Series Landing Page
+
+**Feature Branch**: `kwkraus-series-landing-page-spec`
+
+**Created**: 2026-08-24
+
+**Status**: Draft
+
+**Input**: User description: "I want to create a public landing page for a series that describes the series itself and a table that lists all of the sessions and a registration link that allows anonymous users to register through the link. The page needs to be anonymous and I want the route to be the ID of the series that is currently a GUID which will make it obfuscated. I want the landing page to be professional looking, well laid out, and modern, including mobile friendly."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Series owner turns the public landing page on or off (Priority: P1)
+
+A series owner, managing their series through the existing admin interface, sees a clearly labeled
+control (e.g., a toggle) for making the series' public landing page available. New series default to
+this being off — the public landing page is not reachable until the owner deliberately turns it on.
+Once turned on, the owner can share the landing page URL; if they turn it off again, the page stops
+being publicly reachable.
+
+**Why this priority**: This is the gating control for the entire feature — every other story (viewing
+the page, registering, mobile layout) only matters once an owner has explicitly made a series public.
+Defaulting to off protects series owners from accidentally exposing a series before they intend to.
+
+**Independent Test**: Can be fully tested by creating a new series (confirming the public landing page
+is unreachable by default), turning the control on and confirming the landing page becomes reachable,
+then turning it off and confirming the landing page becomes unreachable again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a newly created series, **When** the owner has not changed anything, **Then** the series'
+   public landing page is off by default and is not reachable by anonymous visitors.
+2. **Given** a series with the public landing page off, **When** the owner turns it on from the admin
+   interface, **Then** the change is saved and the public landing page immediately becomes reachable
+   by anonymous visitors.
+3. **Given** a series with the public landing page on, **When** the owner turns it off, **Then** the
+   change is saved and the public landing page immediately stops being reachable — anonymous requests
+   receive the same generic not-found response used for a nonexistent series.
+4. **Given** the owner is viewing the series in the admin interface, **When** they look at the public
+   landing page control, **Then** its current on/off state is clearly and accurately displayed.
+5. **Given** a user without edit permission on the series, **When** they view the series in the admin
+   interface, **Then** they cannot see or use the control to change the public landing page's on/off
+   state (existing series edit permissions govern this control, consistent with other series settings).
+
+---
+
+### User Story 2 - Anonymous visitor views a series landing page (Priority: P1)
+
+An anonymous visitor (no sign-in) receives a link to a series — for example `/series/{seriesId}` where
+`seriesId` is the series' GUID — and opens it in a browser. Without authenticating, they see the
+series title, its formatted description/outcomes, and a table listing every session in the series
+(name, date/time, and a way to register). This is the entire value of the feature: a shareable,
+public page that explains the series and lets someone register for a session without ever logging in
+or navigating the authenticated app.
+
+**Why this priority**: Without an anonymous, working page at a stable URL, there is no feature —
+everything else is refinement of this one page.
+
+**Independent Test**: Can be fully tested by opening the landing page URL for a known series in a
+private/incognito browser window (no session cookie) and confirming the series title, description,
+and session table render without any sign-in prompt or redirect.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published series with a valid `seriesId`, **When** an unauthenticated visitor navigates
+   to that series' public landing page URL, **Then** the page loads successfully and displays the
+   series title and description without requiring sign-in.
+2. **Given** the same public landing page, **When** it finishes loading, **Then** a table lists every
+   session belonging to the series, each row showing at minimum the session title and its date/time.
+3. **Given** a series whose `Details` field is empty, **When** the public landing page loads, **Then**
+   the page still renders cleanly with the title and session table, omitting the description section
+   entirely rather than showing an empty block.
+4. **Given** the public landing page route, **When** it is requested by any client without an
+   authentication token or session cookie, **Then** the backend serves the response the same as it
+   would for an authenticated request — no login redirect, no 401/403.
+
+---
+
+### User Story 3 - Anonymous visitor registers for a session from the landing page (Priority: P2)
+
+From the session table on the landing page, a visitor finds a session they want to attend and
+activates its registration control, which takes them to that session's external registration
+destination (the same registration URL already stored on the session) to complete sign-up — without
+ever needing an Enablemint Builder account.
+
+**Why this priority**: Viewing the series (P1) delivers informational value on its own, but the
+explicit ask is a page that lets anonymous users register, so this closes the loop and is the second
+most critical slice.
+
+**Independent Test**: Can be fully tested by opening the landing page, locating a session row that has
+a registration link, activating it, and confirming it opens the correct external registration
+destination in a new tab while the landing page remains open.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session in the table has a stored registration URL, **When** the visitor activates that
+   session's Register control, **Then** the registration destination opens in a new browser tab and
+   the landing page remains available in the original tab.
+2. **Given** a session in the table has no stored registration URL, **When** the visitor views that
+   row, **Then** no broken, disabled, or empty Register control is shown for that session — the row
+   simply omits it.
+3. **Given** the visitor is not signed in, **When** they activate a session's Register control,
+   **Then** no Enablemint Builder authentication step is introduced before reaching the external
+   registration destination.
+
+---
+
+### User Story 4 - Landing page looks professional and works on mobile (Priority: P3)
+
+A visitor opens the landing page link on a phone (shared via email, chat, or social media) as easily
+as on a desktop browser. The layout adapts to the smaller screen: the series description remains
+readable, and the session table becomes a stacked/scrollable layout instead of a cramped, unreadable
+grid, while still looking like a polished, modern product page rather than an internal admin screen.
+
+**Why this priority**: This is a quality bar on top of Stories 1 and 2 rather than new capability —
+the page already works functionally without it, but a public-facing, shareable page is judged
+primarily on first impression and mobile usability.
+
+**Independent Test**: Can be fully tested by loading the landing page at common mobile, tablet, and
+desktop viewport widths and confirming the description and session table (and its Register controls)
+remain legible, usable, and free of horizontal overflow or clipped content at each size.
+
+**Acceptance Scenarios**:
+
+1. **Given** the landing page is opened on a narrow mobile viewport, **When** the session table would
+   otherwise overflow horizontally, **Then** it reflows into a mobile-friendly layout (e.g., stacked
+   cards or a scrollable table) with no clipped text or unreachable controls.
+2. **Given** the landing page is opened on desktop, tablet, and mobile viewports in turn, **When**
+   compared side by side, **Then** typography, spacing, and color usage are visually consistent with a
+   professional, modern public web page rather than the authenticated admin UI's dense layout.
+3. **Given** the landing page has no series description, **When** viewed at any supported viewport
+   width, **Then** the layout does not leave an awkward gap or broken section where the description
+   would have been.
+
+---
+
+### Edge Cases
+
+- What happens when the `seriesId` in the URL does not correspond to any existing series? The page
+  shows a generic "not found" state (no series details leaked, no stack trace) rather than an error
+  page that reveals internal information.
+- What happens when the `seriesId` in the URL corresponds to a real series whose public landing page
+  is turned off? The page shows the exact same generic "not found" state as a nonexistent series —
+  visitors cannot distinguish "no such series" from "series exists but isn't public."
+- What happens when an owner turns the public landing page off while a visitor already has it open in
+  a browser tab? The already-open page is not force-closed by this feature; the next time it (or its
+  data) is requested, it is treated as not found.
+- What happens when a series exists but has zero sessions? The page still renders the series title and
+  description, and the session table area shows a neutral "no sessions scheduled yet" message instead
+  of an empty table or error.
+- What happens when a session has already ended? It still appears in the table (visitors sharing the
+  link may want to see past program history), but its Register control is omitted or clearly
+  non-actionable rather than inviting registration for a session that has already occurred.
+- What happens when a session has no registration URL at all? Its row shows no Register control (same
+  behavior as authenticated views today), so visitors aren't misled into thinking registration is
+  possible for that session.
+- How does the system handle very long series titles/descriptions or many sessions? The layout wraps
+  text and the table scrolls or paginates rather than breaking the page layout.
+- What happens if someone tries to reach admin-only actions (edit series, edit session) from this
+  page? No such controls are present or reachable — the page is strictly read-only and registration
+  link-only for anonymous visitors.
+- What happens when the same landing page URL is requested repeatedly (e.g., shared widely on social
+  media)? It continues to serve the same public, read-only content with no rate limiting or
+  authentication introduced by this feature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose a public landing page for a series at a route keyed by the
+  series' existing GUID identifier (`seriesId`), with no additional slug or vanity identifier
+  introduced by this feature.
+- **FR-002**: The public landing page and the data it needs (series title, description, and its
+  sessions with their registration URLs) MUST be reachable without authentication — no sign-in
+  redirect, session cookie, or bearer token is required to view it — but only when the series' public
+  landing page has been turned on (see FR-014).
+- **FR-014**: Each series MUST support an on/off setting controlling whether its public landing page is
+  publicly reachable, defaulting to off for every series (including existing series at the time this
+  feature ships and every newly created series thereafter).
+- **FR-015**: A user with edit permission on the series MUST be able to view and change this on/off
+  setting from the existing admin interface; users without edit permission on the series MUST NOT be
+  able to view or change it, consistent with existing series edit permissions (e.g., series title
+  editing).
+- **FR-016**: When a series' public landing page setting is off, requests to that series' public
+  landing page route (and its underlying data) MUST receive the same generic "not found" response used
+  for a `seriesId` that does not exist (FR-008), so visitors cannot distinguish "off" from
+  "nonexistent."
+- **FR-017**: Turning the public landing page on or off MUST take effect immediately for subsequent
+  requests — no delay, caching window, or additional confirmation step beyond the normal series save
+  behavior.
+- **FR-003**: The public landing page MUST display the series title and, when present, its formatted
+  `Details` description with the same rich-text formatting (bullets, bold, italic, underline) already
+  supported for series details; when `Details` is empty, the description section MUST be omitted
+  entirely.
+- **FR-004**: The public landing page MUST display a table (or equivalent structured list) of every
+  session belonging to the series, showing at minimum each session's title and start date/time.
+- **FR-005**: For each session that has a stored registration URL, the table MUST present a Register
+  control that opens the registration destination in a new browser tab, leaving the landing page open
+  in its original tab.
+- **FR-006**: For each session that has no stored registration URL, the table MUST omit the Register
+  control entirely for that row rather than showing it disabled or empty.
+- **FR-007**: The public landing page MUST NOT expose any owner-only or authenticated-only data or
+  actions (e.g., session/series edit controls, internal metrics, owner identity) — it is strictly a
+  read-only, registration-link-only surface.
+- **FR-008**: When the requested `seriesId` does not correspond to an existing series, the system MUST
+  respond with a generic "not found" page state and MUST NOT leak information about whether a series
+  ID is valid versus simply inaccessible.
+- **FR-009**: When a series has no sessions, the landing page MUST render the series title/description
+  normally and show a neutral empty-state message in place of the session table.
+- **FR-010**: The public landing page layout MUST be responsive: it MUST remain fully readable and
+  usable (no horizontal overflow, no clipped text, no unreachable controls) at common mobile, tablet,
+  and desktop viewport widths.
+- **FR-011**: The public landing page MUST be visually distinct from the authenticated admin UI in
+  tone — professional, modern, marketing-appropriate styling — while reusing the product's existing
+  design system (colors, typography, components) rather than introducing an unrelated visual identity.
+- **FR-012**: The public landing page route MUST NOT require or accept any series/session mutation —
+  it is a read path only; no create, update, or delete operation is reachable from it.
+- **FR-013**: Sessions that have already ended MUST still appear in the session table, but MUST NOT
+  present an active Register control implying registration is still possible.
+
+### Key Entities *(include if feature involves data)*
+
+- **Series**: The existing series entity (`SeriesId`, `Title`, `Details`), gaining one new attribute —
+  an on/off setting (e.g., `IsPublic`, defaulting to off/`false`) controlling whether its public
+  landing page is reachable. This feature otherwise exposes existing title/details data through a new
+  anonymous read surface.
+- **Session**: The existing session entity (`SessionId`, `SeriesId`, `Title`, `StartsAt`, `EndsAt`,
+  `RegistrationUrl`, `Description`). This feature adds no new attributes; it exposes existing
+  title/schedule/registration data for sessions belonging to the requested series through the same new
+  anonymous read surface.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An anonymous visitor with only the series landing page URL can view the series
+  description and full session list within 3 seconds on a typical broadband connection, with zero
+  authentication prompts.
+- **SC-002**: 100% of sessions with a stored registration URL present a working Register control that
+  opens the correct destination in a new tab; 100% of sessions without one show no Register control.
+- **SC-003**: The landing page renders without horizontal overflow, clipped content, or unusable
+  controls at mobile (≈375px), tablet (≈768px), and desktop (≈1280px+) viewport widths.
+- **SC-004**: Requests for a non-existent `seriesId`, and requests for a real `seriesId` whose public
+  landing page is off, both return the identical generic not-found state in 100% of cases, with no
+  internal error details or stack traces surfaced.
+- **SC-006**: 100% of newly created series and 100% of series that existed before this feature default
+  to the public landing page being off, verified by attempting to reach each one's landing page before
+  any owner action.
+- **SC-007**: An owner can turn a series' public landing page on or off from the admin interface in
+  under 10 seconds, with the change taking effect for the very next public request.
+- **SC-005**: No owner-only data (internal metrics, owner identity, edit affordances) is present in the
+  public landing page's rendered output or underlying API response, verified across all series states
+  (with/without description, with/without sessions).
+
+## Assumptions
+
+- The obfuscation requirement is satisfied by keying the route on the series' existing GUID
+  (`SeriesId`); no new short-lived token, slug, or separate "public ID" is introduced. A GUID is
+  effectively unguessable, so no additional access-control mechanism (e.g., password, expiring link)
+  is required for this feature.
+- "Public" and "anonymous" mean that, once an owner turns a series' public landing page on, its page
+  and backing data become reachable by anyone with the URL — no further access control (password,
+  expiring link, allow-list) is layered on top for this feature. The on/off setting itself is the
+  publish/unpublish control; no separate "publish" mechanism is introduced.
+- The on/off setting is a simple boolean stored on the series and edited the same way other series
+  settings are edited (inline save with error banner on failure), consistent with existing series field
+  editing patterns; no scheduling (e.g., "publish on this date") or approval workflow is introduced.
+- The session table displays all sessions for the series regardless of whether they are past, current,
+  or upcoming, matching the existing "series details" session list behavior; past sessions are shown
+  for context but without an actionable Register control.
+- Registration behavior mirrors the existing authenticated Registration Link behavior (FR-010 in
+  specs/002-session-registration-url): opens in a new tab, no reachability validation performed by
+  this product.
+- The series description reuses the existing sanitized rich-text `Details` field and its existing
+  supported formatting (bullets, bold, italic, underline); no new formatting capability is introduced.
+- No new data fields are required on Series or Session; this feature is purely a new anonymous
+  read/display surface over existing data.
+- Styling reuses the existing Next.js/Tailwind/Primer-based design system already used elsewhere in
+  the product, adapted for a public marketing-style presentation rather than the authenticated admin
+  layout.
+- Session capacity, waitlisting, and confirmation flows are handled entirely by the external
+  registration destination; this feature only links out to that destination and tracks nothing about
+  registration outcomes.

--- a/specs/004-public-series-landing-page/tasks.md
+++ b/specs/004-public-series-landing-page/tasks.md
@@ -1,0 +1,254 @@
+---
+
+description: "Task list for Public Series Landing Page"
+
+---
+
+# Tasks: Public Series Landing Page
+
+**Input**: Design documents from `/specs/004-public-series-landing-page/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/public-series-api.md, quickstart.md
+
+**Tests**: Included — the plan and quickstart explicitly require xUnit backend coverage and Playwright E2E coverage before/alongside implementation.
+
+**Organization**: Tasks are grouped by user story (US1–US4) to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+
+## Path Conventions
+
+Web application split per plan.md: `src/backend/` (ASP.NET Core minimal API), `src/frontend/` (Next.js App Router), `tests/backend/`, `src/frontend/e2e/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the project builds cleanly before any feature work begins.
+
+- [X] T001 Verify backend builds with `dotnet build` from `src/backend` and frontend builds with `npm run build` from `src/frontend` (no code changes; establishes a clean baseline)
+- [X] T002 [P] Confirm `dotnet test tests/backend/EnableFront.Builder.Api.Tests/EnableFront.Builder.Api.Tests.csproj` passes on current `main` before changes (baseline for regression comparison)
+- [X] T003 [P] Confirm `npm run lint` passes in `src/frontend` before changes (baseline for regression comparison)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core `IsPublic` data model, migration, and shared DTO plumbing that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Add `public bool IsPublic { get; set; } = false;` property to `Series` entity in `src/backend/Domain/Entities/Series.cs`
+- [X] T005 Add EF Core migration `AddIsPublicToSeries` (non-nullable `bit` column, default `0`/`false`) via `dotnet ef migrations add AddIsPublicToSeries` from `src/backend`, producing `src/backend/Migrations/{timestamp}_AddIsPublicToSeries.cs`, `.Designer.cs`, and updating `src/backend/Migrations/AppDbContextModelSnapshot.cs`
+- [X] T006 Add `IsPublic` field to `UpdateSeriesRequest` in `src/backend/Features/Series/Dtos/UpdateSeriesRequest.cs`, defaulting to the series' current stored value when omitted by an older client (no silent reset to `false` on unrelated saves)
+- [X] T007 Add `IsPublic` field to `SeriesResponseDto` in `src/backend/Features/Series/Dtos/SeriesResponseDto.cs` so the admin UI can read current on/off state
+- [X] T008 Persist `IsPublic` on `UpdateAsync` in `src/backend/Features/Series/SeriesService.cs`, preserving the existing `OwnerUserId` ownership check as the sole authorization boundary for the change
+
+**Checkpoint**: `IsPublic` column, migration, and admin-side DTOs/service exist — user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Series owner turns the public landing page on or off (Priority: P1) 🎯 MVP (gate)
+
+**Goal**: A series owner sees an `IsPublic` toggle in the admin interface (permission-gated like `Title` editing), can turn it on/off, and the change takes effect immediately for the (not-yet-built) public endpoint's gating logic.
+
+**Independent Test**: Create a new series (confirm `IsPublic` defaults to `false` in `SeriesResponseDto`), toggle it on via `PUT /api/v1/series/{id}` and confirm the response reflects `true`, then toggle it off and confirm it reflects `false` again; confirm a caller without edit permission cannot change it.
+
+### Tests for User Story 1 ⚠️
+
+- [X] T009 [P] [US1] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesServiceTests.cs` verifying `CreateAsync` defaults `IsPublic` to `false`
+- [X] T010 [P] [US1] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesServiceTests.cs` verifying `UpdateAsync` persists an owner-supplied `IsPublic` value (`false → true` and `true → false`)
+- [X] T011 [P] [US1] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesServiceTests.cs` verifying `UpdateAsync` preserves the existing stored `IsPublic` value when the request omits the field (no silent reset)
+- [X] T012 [P] [US1] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesDetailsApiContractTests.cs` verifying a caller without edit permission on the series cannot change `IsPublic` via `PUT /api/v1/series/{id}` (existing ownership-check behavior, unchanged status code)
+- [X] T013 [P] [US1] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesDetailsApiContractTests.cs` verifying `GET`/`PUT` responses for `/api/v1/series/{id}` include `isPublic` in the JSON body
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Create `series-visibility-toggle.tsx` component in `src/frontend/components/series-visibility-toggle.tsx` rendering the on/off control with its current state, calling the existing series update API on change, and hidden/disabled when the current user lacks edit permission (mirrors existing title-edit permission gating)
+- [X] T015 [US1] Wire `series-visibility-toggle.tsx` into the admin series page `src/frontend/app/series/[id]/page.tsx`, alongside existing title/details editing controls
+- [X] T016 [US1] Add structured logging (no PII) around `IsPublic` toggle changes in `src/backend/Features/Series/SeriesService.cs`, consistent with existing endpoint logging conventions (Constitution VI)
+
+**Checkpoint**: Owners can see and toggle `IsPublic` from the admin UI; the flag persists correctly and is authorization-gated. This story is the mandatory gate for US2–US4 (their independent tests all require a series with `IsPublic` settable).
+
+---
+
+## Phase 4: User Story 2 - Anonymous visitor views a series landing page (Priority: P1)
+
+**Goal**: An anonymous visitor can open `/public/series/{seriesId}` (frontend) backed by an anonymous `GET /api/v1/public/series/{id}` (backend) and see the series title, formatted details, and full session table — with "off" and "not found" returning identical responses.
+
+**Independent Test**: Open the landing page URL for a known `IsPublic == true` series in a private/incognito window and confirm title, description, and session table render without any sign-in prompt; open it for an `IsPublic == false` series and for a nonexistent id and confirm both show the identical generic not-found state.
+
+### Tests for User Story 2 ⚠️
+
+- [X] T017 [P] [US2] Create `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` with a test asserting `GET /api/v1/public/series/{id}` returns `200` with title/details/sessions when `IsPublic == true`
+- [X] T018 [P] [US2] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting the endpoint returns `404` with the identical `series_not_found` shape when `IsPublic == false`
+- [X] T019 [P] [US2] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting the endpoint returns `404` with the identical `series_not_found` shape when `id` does not match any series
+- [X] T020 [P] [US2] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting the `200` response never contains `ownerUserId`, `seriesId`, `isPublic`, or metrics fields
+- [X] T021 [P] [US2] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting the endpoint is reachable with no `Authorization` header or session cookie (no 401/403)
+- [X] T022 [P] [US2] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting a series with empty `Details` returns `details: null` and a series with zero sessions returns `sessions: []`
+- [X] T023 [P] [US2] Create `src/frontend/e2e/public-series-landing.spec.ts` with a Playwright scenario asserting an anonymous browser context (no auth cookie) loads `/public/series/{id}` for a public series and sees the title, formatted details, and session table (title + start date/time per row) without a sign-in redirect
+- [X] T024 [P] [US2] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a public series with empty `Details` renders cleanly with no empty/broken description section
+- [X] T025 [P] [US2] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a public series with zero sessions shows a neutral "no sessions scheduled yet" message instead of an empty table
+- [X] T026 [P] [US2] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting both a nonexistent `id` and a real-but-private (`IsPublic == false`) `id` render the identical generic not-found page
+
+### Implementation for User Story 2
+
+- [X] T027 [US2] Create `PublicSeriesResponseDto` and `PublicSessionDto` records in `src/backend/Features/Series/Public/Dtos/PublicSeriesResponseDto.cs` and `src/backend/Features/Series/Public/Dtos/PublicSessionDto.cs` per contracts/public-series-api.md (no `SeriesId`, `OwnerUserId`, `IsPublic`, or metrics fields)
+- [X] T028 [US2] Create `PublicSeriesService` in `src/backend/Features/Series/Public/PublicSeriesService.cs` with a `GetPublicSeriesAsync(Guid id)` method that returns `null` when no series exists for `id` **or** when `series.IsPublic == false`, and otherwise projects the series and its sessions into `PublicSeriesResponseDto` (batched session load, no N+1)
+- [X] T029 [US2] Create `PublicSeriesEndpoints` in `src/backend/Features/Series/Public/PublicSeriesEndpoints.cs` registering `MapGroup("/api/v1/public/series")` (no `.RequireAuthorization()`) with `GET /{id}` mapping a `null` service result to the existing `series_not_found` `404` shape and a non-null result to `200 OK` with `PublicSeriesResponseDto`
+- [X] T030 [US2] Register the new `PublicSeriesEndpoints` group in the application's endpoint/startup wiring (e.g., `Program.cs`), verifying it is registered separately from the existing authenticated `Features/Series/SeriesEndpoints.cs` group
+- [X] T031 [US2] Add structured logging (no PII) for anonymous public-series requests in `src/backend/Features/Series/Public/PublicSeriesService.cs`, consistent with existing endpoint logging conventions (Constitution VI)
+- [X] T032 [P] [US2] Create `src/frontend/app/public/series/[id]/page.tsx` as a server component fetching `GET /api/v1/public/series/{id}` and rendering series title, details (via the existing `lib/series-details-html.tsx` sanitized-HTML helper), and session table
+- [X] T033 [P] [US2] Create `src/frontend/app/public/series/[id]/not-found.tsx` rendering the generic not-found state for both nonexistent and private series responses
+- [X] T034 [P] [US2] Create `src/frontend/app/public/series/[id]/loading.tsx` rendering a loading skeleton for the public landing page
+- [X] T035 [US2] Create `public-series-landing.tsx` component in `src/frontend/components/public-series-landing.tsx` rendering the series title, details section (omitted when empty per FR-003), and session table (or "no sessions scheduled yet" empty state per FR-009), wired into `app/public/series/[id]/page.tsx`
+
+**Checkpoint**: Anonymous visitors can view any `IsPublic == true` series' landing page; private/nonexistent series both show the identical not-found state. US1 + US2 together deliver the feature's core informational value.
+
+---
+
+## Phase 5: User Story 3 - Anonymous visitor registers for a session from the landing page (Priority: P2)
+
+**Goal**: Each session row with a stored `registrationUrl` shows a Register control opening the destination in a new tab; rows without one, or for already-ended sessions, show no active Register control.
+
+**Independent Test**: Open the landing page, locate a session row with a registration link, activate it, and confirm it opens the correct external destination in a new tab while the landing page remains open in the original tab; confirm a row with no `registrationUrl`, and a row for an already-ended session, show no active Register control.
+
+### Tests for User Story 3 ⚠️
+
+- [X] T036 [P] [US3] Add test in `tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs` asserting sessions with no `RegistrationUrl` are present in `sessions[]` with `registrationUrl: null`
+- [X] T037 [P] [US3] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a session row with a `registrationUrl` shows a Register control that opens the destination in a new tab while the landing page remains open in the original tab
+- [X] T038 [P] [US3] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a session row with no `registrationUrl` shows no Register control (not disabled, not empty)
+- [X] T039 [P] [US3] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a session whose `endsAt` is in the past appears in the table without an active Register control, even if it has a `registrationUrl`
+
+### Implementation for User Story 3
+
+- [X] T040 [US3] Add per-row Register control logic to `src/frontend/components/public-series-landing.tsx`: render a link (`target="_blank"`, `rel="noopener noreferrer"`) opening `registrationUrl` only when non-null and the session's `endsAt` is in the future; omit the control entirely otherwise
+
+**Checkpoint**: The landing page closes the registration loop end-to-end; US1–US3 together satisfy the feature's explicit ask (public page + anonymous registration).
+
+---
+
+## Phase 6: User Story 4 - Landing page looks professional and works on mobile (Priority: P3)
+
+**Goal**: The landing page reflows cleanly at mobile (~375px), tablet (~768px), and desktop (~1280px+) viewport widths, with a professional, modern presentation reusing the existing design system rather than the admin UI's dense layout.
+
+**Independent Test**: Load the landing page at mobile, tablet, and desktop viewport widths and confirm the description and session table (and its Register controls) remain legible, usable, and free of horizontal overflow or clipped content at each size; confirm a series with no description leaves no awkward gap.
+
+### Tests for User Story 4 ⚠️
+
+- [X] T041 [P] [US4] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting the session table reflows into a mobile-friendly stacked/scrollable layout (no horizontal overflow, no clipped text, no unreachable controls) at a ~375px viewport
+- [X] T042 [P] [US4] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting the layout is free of horizontal overflow or clipped content at ~768px (tablet) and ~1280px+ (desktop) viewports
+- [X] T043 [P] [US4] Add scenario to `src/frontend/e2e/public-series-landing.spec.ts` asserting a series with no description leaves no awkward gap or broken section at any supported viewport width
+
+### Implementation for User Story 4
+
+- [X] T044 [US4] Implement responsive session table styling in `src/frontend/components/public-series-landing.tsx` using Tailwind responsive utilities: a table layout on wider viewports, a stacked card list below the `sm:`/`md:` breakpoint
+- [X] T045 [US4] Apply professional, modern public-facing styling (typography, spacing, color usage) to `src/frontend/components/public-series-landing.tsx` and `src/frontend/app/public/series/[id]/page.tsx` using existing Tailwind/Primer design tokens, visually distinct in tone from the authenticated admin UI
+
+**Checkpoint**: All four user stories are independently functional; the feature is complete end-to-end.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all stories.
+
+- [X] T046 [P] Run `dotnet test tests/backend/EnableFront.Builder.Api.Tests/EnableFront.Builder.Api.Tests.csproj` from `src/backend` and confirm all new and existing tests pass
+- [X] T047 [P] Run `npm run lint` and `npm run build` from `src/frontend` and confirm no new lint/build errors
+- [ ] T048 [P] Run `npm run test:e2e -- e2e/public-series-landing.spec.ts` from `src/frontend` and confirm all scenarios pass
+- [ ] T049 Execute the full quickstart.md validation checklist (backend + frontend) end-to-end and confirm every listed scenario behaves as documented
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational. Acts as a **hard gate** for US2–US4: those stories' independent tests all require a series whose `IsPublic` value can be set to `true`/`false`, which only exists once US1's toggle and persistence are implemented.
+- **User Story 2 (Phase 4)**: Depends on Foundational + US1 (needs `IsPublic` settable to exercise on/off/not-found parity). Delivers the core anonymous read experience.
+- **User Story 3 (Phase 5)**: Depends on Foundational + US1 + US2 (extends the session table US2 renders). Not independently testable without US2's page existing.
+- **User Story 4 (Phase 6)**: Depends on Foundational + US1 + US2 (+ US3 for Register-control responsiveness). Purely a presentation/quality layer over US2/US3's existing markup.
+- **Polish (Phase 7)**: Depends on all four user stories being complete.
+
+### User Story Dependencies
+
+Unlike a typical spec-kit feature where user stories are fully independent, this feature has a linear dependency chain because each story builds directly on the previous one's UI surface (session table) and gating flag:
+
+- **US1 (P1)**: No dependency on other stories (only Foundational). Independently testable via the admin toggle + API response alone.
+- **US2 (P1)**: Requires US1's `IsPublic` flag to exist and be settable to test on/off/not-found parity.
+- **US3 (P2)**: Requires US2's session table to exist to add Register controls to it.
+- **US4 (P3)**: Requires US2's (and US3's) markup to exist to make it responsive/polished.
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation.
+- Backend DTOs/service before endpoints; endpoints before frontend page wiring.
+- Core implementation before logging/polish additions.
+- Story complete (and its Checkpoint validated) before moving to the next priority.
+
+### Parallel Opportunities
+
+- T002 and T003 (Setup baselines) can run in parallel.
+- T009–T013 (US1 backend tests, same file `SeriesServiceTests.cs`/`SeriesDetailsApiContractTests.cs`) are logically parallel but touch shared files — treat as sequential edits to the same file in practice, or split across two developers working file-by-file.
+- T017–T022 (US2 backend tests) and T023–T026 (US2 E2E tests) can run in parallel with each other (different files/languages).
+- T032, T033, T034 (US2 frontend route files: `page.tsx`, `not-found.tsx`, `loading.tsx`) can run in parallel — different files.
+- T036–T039 (US3 tests) can run in parallel with each other.
+- T041–T043 (US4 tests) can run in parallel with each other.
+- T046, T047, T048 (Polish validation runs) can run in parallel.
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch backend contract/unit tests for User Story 2 together:
+Task: "GET /api/v1/public/series/{id} returns 200 with title/details/sessions when IsPublic == true"
+Task: "GET /api/v1/public/series/{id} returns 404 identical shape when IsPublic == false"
+Task: "GET /api/v1/public/series/{id} returns 404 identical shape when id does not exist"
+
+# Launch new frontend route files for User Story 2 together:
+Task: "Create app/public/series/[id]/page.tsx"
+Task: "Create app/public/series/[id]/not-found.tsx"
+Task: "Create app/public/series/[id]/loading.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + User Story 2)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories).
+3. Complete Phase 3: User Story 1 (the gating toggle — required before anything is publicly reachable).
+4. Complete Phase 4: User Story 2 (the anonymous view — the feature's core value).
+5. **STOP and VALIDATE**: Confirm an owner can publish a series and an anonymous visitor can view it, with off/not-found parity holding.
+6. Deploy/demo if ready — this is the smallest slice that delivers the feature's stated purpose.
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → owner can toggle visibility (not yet publicly visible without US2).
+3. US1 + US2 → MVP: anonymous visitors can view published series. Deploy/Demo.
+4. + US3 → anonymous visitors can register from the page. Deploy/Demo.
+5. + US4 → page is responsive and professionally styled. Deploy/Demo (feature complete).
+
+### Team Strategy
+
+Because US2 depends on US1, US3 depends on US2, and US4 depends on US2/US3, this feature is best delivered **sequentially by priority** rather than fully parallelized across developers, even though tasks within each story phase (marked `[P]`) can be split among team members.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies.
+- `[Story]` label maps task to specific user story for traceability.
+- This feature's user stories have a linear dependency chain (US1 → US2 → US3 → US4) rather than being fully independent; each Checkpoint should still be validated before proceeding to preserve incremental, demoable delivery.
+- Verify tests fail before implementing.
+- Commit after each task or logical group.
+- Avoid: vague tasks, same-file conflicts, skipping the US1 gate before starting US2.

--- a/src/backend/Domain/Entities/Series.cs
+++ b/src/backend/Domain/Entities/Series.cs
@@ -6,6 +6,22 @@ public class Series
     public string OwnerUserId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string? Details { get; set; }
+
+    /// <summary>
+    /// Gates the anonymous public landing page (see specs/004-public-series-landing-page).
+    /// Defaults to <see langword="false"/> for every new and existing series; only the owner can
+    /// toggle it via the same update path used for <see cref="Title"/>/<see cref="Details"/>.
+    /// </summary>
+    public bool IsPublic { get; set; } = false;
+
+    /// <summary>
+    /// Optional custom banner image URL for the public landing page. <see langword="null"/> means
+    /// no custom image has been set, in which case the public page renders a bundled stock banner.
+    /// Reserved for a future owner-facing image upload/URL editor; today it can only be seeded
+    /// directly (no API surface sets it yet).
+    /// </summary>
+    public string? ImageUrl { get; set; }
+
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 }

--- a/src/backend/Features/Series/Dtos/SeriesResponseDto.cs
+++ b/src/backend/Features/Series/Dtos/SeriesResponseDto.cs
@@ -4,5 +4,7 @@ public record SeriesResponseDto(
     Guid SeriesId,
     string Title,
     string? Details,
+    bool IsPublic,
+    string? ImageUrl,
     DateTime CreatedAt,
     DateTime UpdatedAt);

--- a/src/backend/Features/Series/Dtos/UpdateSeriesRequest.cs
+++ b/src/backend/Features/Series/Dtos/UpdateSeriesRequest.cs
@@ -1,3 +1,7 @@
 namespace EnableFront.Builder.Features.Series.Dtos;
 
-public record UpdateSeriesRequest(string Title, string? Details = null);
+/// <summary>
+/// <paramref name="IsPublic"/> is nullable so an older client that omits the field leaves the
+/// series' current stored visibility unchanged rather than silently resetting it to <c>false</c>.
+/// </summary>
+public record UpdateSeriesRequest(string Title, string? Details = null, bool? IsPublic = null);

--- a/src/backend/Features/Series/Public/Dtos/PublicSeriesResponseDto.cs
+++ b/src/backend/Features/Series/Public/Dtos/PublicSeriesResponseDto.cs
@@ -1,0 +1,12 @@
+namespace EnableFront.Builder.Features.Series.Public.Dtos;
+
+/// <summary>
+/// Anonymous, read-only projection of a public series. Deliberately excludes
+/// <c>SeriesId</c>, <c>OwnerUserId</c>, <c>IsPublic</c>, and any metrics — see
+/// specs/004-public-series-landing-page/contracts/public-series-api.md.
+/// </summary>
+public record PublicSeriesResponseDto(
+    string Title,
+    string? Details,
+    string? ImageUrl,
+    IReadOnlyList<PublicSessionDto> Sessions);

--- a/src/backend/Features/Series/Public/Dtos/PublicSessionDto.cs
+++ b/src/backend/Features/Series/Public/Dtos/PublicSessionDto.cs
@@ -1,0 +1,13 @@
+namespace EnableFront.Builder.Features.Series.Public.Dtos;
+
+/// <summary>
+/// Anonymous, read-only projection of a session within a public series landing page.
+/// Excludes <c>OwnerUserId</c> and any metrics fields.
+/// </summary>
+public record PublicSessionDto(
+    Guid SessionId,
+    string Title,
+    DateTime StartsAt,
+    DateTime EndsAt,
+    string? RegistrationUrl,
+    string? Description);

--- a/src/backend/Features/Series/Public/PublicSeriesEndpoints.cs
+++ b/src/backend/Features/Series/Public/PublicSeriesEndpoints.cs
@@ -15,9 +15,13 @@ public static class PublicSeriesEndpoints
     {
         var group = app.MapGroup("/api/v1/public/series");
 
-        group.MapGet("/{id:guid}", async (Guid id, PublicSeriesService service, HttpContext ctx) =>
+        group.MapGet("/{id:guid}", async (
+            Guid id,
+            PublicSeriesService service,
+            HttpContext ctx,
+            CancellationToken cancellationToken) =>
         {
-            var result = await service.GetPublicSeriesAsync(id);
+            var result = await service.GetPublicSeriesAsync(id, cancellationToken);
             return result is null
                 ? Results.NotFound(new ErrorEnvelope(
                     "series_not_found", "Series not found.", ctx.TraceIdentifier))

--- a/src/backend/Features/Series/Public/PublicSeriesEndpoints.cs
+++ b/src/backend/Features/Series/Public/PublicSeriesEndpoints.cs
@@ -1,0 +1,29 @@
+using EnableFront.Builder.Common;
+
+namespace EnableFront.Builder.Features.Series.Public;
+
+/// <summary>
+/// Anonymous read-only endpoint group for the public series landing page. Deliberately kept
+/// separate from <see cref="EnableFront.Builder.Features.Series.SeriesEndpoints"/> — this group
+/// has no <c>.RequireAuthorization()</c> call so it can never accidentally weaken the existing
+/// authenticated group's protection. See specs/004-public-series-landing-page/research.md
+/// Decision 2.
+/// </summary>
+public static class PublicSeriesEndpoints
+{
+    public static WebApplication MapPublicSeriesEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v1/public/series");
+
+        group.MapGet("/{id:guid}", async (Guid id, PublicSeriesService service, HttpContext ctx) =>
+        {
+            var result = await service.GetPublicSeriesAsync(id);
+            return result is null
+                ? Results.NotFound(new ErrorEnvelope(
+                    "series_not_found", "Series not found.", ctx.TraceIdentifier))
+                : Results.Ok(result);
+        });
+
+        return app;
+    }
+}

--- a/src/backend/Features/Series/Public/PublicSeriesService.cs
+++ b/src/backend/Features/Series/Public/PublicSeriesService.cs
@@ -1,0 +1,54 @@
+using EnableFront.Builder.Features.Series.Public.Dtos;
+using EnableFront.Builder.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnableFront.Builder.Features.Series.Public;
+
+public class PublicSeriesService
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<PublicSeriesService>? _logger;
+
+    public PublicSeriesService(AppDbContext db, ILogger<PublicSeriesService>? logger = null)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the public projection for <paramref name="id"/>, or <see langword="null"/> when no
+    /// series exists for that id <em>or</em> when the series exists but <c>IsPublic == false</c>.
+    /// Both cases are intentionally indistinguishable to callers (see FR-008/FR-016/SC-004/SC-005):
+    /// the caller (endpoint) must map a null result to the same generic not-found response either
+    /// way, so this method never signals which case occurred.
+    /// </summary>
+    public async Task<PublicSeriesResponseDto?> GetPublicSeriesAsync(Guid id)
+    {
+        var series = await _db.Series
+            .FirstOrDefaultAsync(s => s.SeriesId == id && s.IsPublic);
+
+        if (series is null)
+        {
+            _logger?.LogInformation("Public series request for {SeriesId} resolved to not-found", id);
+            return null;
+        }
+
+        var sessions = await _db.Sessions
+            .Where(s => s.SeriesId == id)
+            .OrderBy(s => s.StartsAt)
+            .Select(s => new PublicSessionDto(
+                s.SessionId,
+                s.Title,
+                s.StartsAt,
+                s.EndsAt,
+                s.RegistrationUrl,
+                s.Description))
+            .ToListAsync();
+
+        _logger?.LogInformation(
+            "Public series request for {SeriesId} resolved to a public series with {SessionCount} sessions",
+            id, sessions.Count);
+
+        return new PublicSeriesResponseDto(series.Title, series.Details, series.ImageUrl, sessions);
+    }
+}

--- a/src/backend/Features/Series/Public/PublicSeriesService.cs
+++ b/src/backend/Features/Series/Public/PublicSeriesService.cs
@@ -22,10 +22,12 @@ public class PublicSeriesService
     /// the caller (endpoint) must map a null result to the same generic not-found response either
     /// way, so this method never signals which case occurred.
     /// </summary>
-    public async Task<PublicSeriesResponseDto?> GetPublicSeriesAsync(Guid id)
+    public async Task<PublicSeriesResponseDto?> GetPublicSeriesAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
     {
         var series = await _db.Series
-            .FirstOrDefaultAsync(s => s.SeriesId == id && s.IsPublic);
+            .FirstOrDefaultAsync(s => s.SeriesId == id && s.IsPublic, cancellationToken);
 
         if (series is null)
         {
@@ -43,7 +45,7 @@ public class PublicSeriesService
                 s.EndsAt,
                 s.RegistrationUrl,
                 s.Description))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         _logger?.LogInformation(
             "Public series request for {SeriesId} resolved to a public series with {SessionCount} sessions",

--- a/src/backend/Features/Series/SeriesService.cs
+++ b/src/backend/Features/Series/SeriesService.cs
@@ -8,10 +8,12 @@ namespace EnableFront.Builder.Features.Series;
 public class SeriesService
 {
     private readonly AppDbContext _db;
+    private readonly ILogger<SeriesService>? _logger;
 
-    public SeriesService(AppDbContext db)
+    public SeriesService(AppDbContext db, ILogger<SeriesService>? logger = null)
     {
         _db = db;
+        _logger = logger;
     }
 
     public async Task<IEnumerable<SeriesListItemDto>> GetAllAsync(string ownerUserId)
@@ -85,10 +87,22 @@ public class SeriesService
         // Validate before mutating anything so a rejected update never persists partial content.
         var sanitizedDetails = SanitizeDetailsOrThrow(req.Details);
 
+        var previousIsPublic = series.IsPublic;
+
         series.Title = req.Title;
         series.Details = sanitizedDetails;
+        // Null means the client omitted the field: preserve the current stored value rather than
+        // silently resetting visibility to false on an unrelated save.
+        series.IsPublic = req.IsPublic ?? series.IsPublic;
         series.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
+
+        if (series.IsPublic != previousIsPublic)
+        {
+            _logger?.LogInformation(
+                "Series {SeriesId} public visibility changed from {PreviousIsPublic} to {IsPublic}",
+                series.SeriesId, previousIsPublic, series.IsPublic);
+        }
 
         return ToResponseDto(series);
     }
@@ -120,5 +134,5 @@ public class SeriesService
     }
 
     private static SeriesResponseDto ToResponseDto(Domain.Entities.Series s) =>
-        new(s.SeriesId, s.Title, s.Details, s.CreatedAt, s.UpdatedAt);
+        new(s.SeriesId, s.Title, s.Details, s.IsPublic, s.ImageUrl, s.CreatedAt, s.UpdatedAt);
 }

--- a/src/backend/Migrations/20260824215310_AddIsPublicToSeries.Designer.cs
+++ b/src/backend/Migrations/20260824215310_AddIsPublicToSeries.Designer.cs
@@ -4,6 +4,7 @@ using EnableFront.Builder.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnableFront.Builder.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824215310_AddIsPublicToSeries")]
+    partial class AddIsPublicToSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -109,9 +112,6 @@ namespace EnableFront.Builder.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("ImageUrl")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsPublic")

--- a/src/backend/Migrations/20260824215310_AddIsPublicToSeries.cs
+++ b/src/backend/Migrations/20260824215310_AddIsPublicToSeries.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnableFront.Builder.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsPublicToSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublic",
+                table: "Series",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPublic",
+                table: "Series");
+        }
+    }
+}

--- a/src/backend/Migrations/20260824223202_AddImageUrlToSeries.Designer.cs
+++ b/src/backend/Migrations/20260824223202_AddImageUrlToSeries.Designer.cs
@@ -4,6 +4,7 @@ using EnableFront.Builder.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EnableFront.Builder.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824223202_AddImageUrlToSeries")]
+    partial class AddImageUrlToSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/Migrations/20260824223202_AddImageUrlToSeries.cs
+++ b/src/backend/Migrations/20260824223202_AddImageUrlToSeries.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EnableFront.Builder.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageUrlToSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ImageUrl",
+                table: "Series",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImageUrl",
+                table: "Series");
+        }
+    }
+}

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -3,6 +3,7 @@ using EnableFront.Builder.Features.Export;
 using EnableFront.Builder.Features.Me;
 using EnableFront.Builder.Features.Metrics;
 using EnableFront.Builder.Features.Series;
+using EnableFront.Builder.Features.Series.Public;
 using EnableFront.Builder.Features.Sessions;
 using EnableFront.Builder.Infrastructure.Data;
 using EnableFront.Builder.Infrastructure.Graph;
@@ -61,6 +62,7 @@ builder.Services.AddSingleton(sp =>
 
 // Feature services
 builder.Services.AddScoped<SeriesService>();
+builder.Services.AddScoped<PublicSeriesService>();
 builder.Services.AddScoped<SessionService>();
 builder.Services.AddScoped<MetricsService>();
 builder.Services.AddScoped<MarkdownExportService>();
@@ -125,6 +127,7 @@ app.MapGet("/api/time", () =>
 
 // Feature endpoints
 app.MapSeriesEndpoints();
+app.MapPublicSeriesEndpoints();
 app.MapSessionEndpoints();
 app.MapMetricsEndpoints();
 app.MapMeEndpoints();

--- a/src/frontend/app/public/series/[id]/error.tsx
+++ b/src/frontend/app/public/series/[id]/error.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { ErrorBanner } from '@/components/error-banner'
+
+interface PublicSeriesErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function PublicSeriesError({ error, reset }: PublicSeriesErrorProps) {
+  const router = useRouter()
+
+  return (
+    <div className="space-y-4 py-8">
+      <ErrorBanner
+        message={error.message || 'Failed to load the public series. Please try again.'}
+        onRetry={() => {
+          reset()
+          router.refresh()
+        }}
+      />
+    </div>
+  )
+}

--- a/src/frontend/app/public/series/[id]/loading.tsx
+++ b/src/frontend/app/public/series/[id]/loading.tsx
@@ -1,0 +1,21 @@
+/** Route-level loading skeleton shown while the public series page streams in. */
+export default function PublicSeriesLoading() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 sm:py-16" aria-busy="true" aria-label="Loading series…">
+      <div className="mb-10 flex flex-col items-center gap-3 text-center sm:mb-14">
+        <div className="h-3 w-32 animate-pulse rounded" style={{ backgroundColor: 'var(--bgColor-muted)' }} />
+        <div className="h-9 w-2/3 animate-pulse rounded" style={{ backgroundColor: 'var(--bgColor-muted)' }} />
+        <div className="h-4 w-1/2 animate-pulse rounded" style={{ backgroundColor: 'var(--bgColor-muted)' }} />
+      </div>
+      <div className="flex flex-col gap-3">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="h-20 animate-pulse rounded-xl"
+            style={{ backgroundColor: 'var(--bgColor-muted)' }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/app/public/series/[id]/not-found.tsx
+++ b/src/frontend/app/public/series/[id]/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+/**
+ * Rendered by Next.js when `notFound()` is called from the public series
+ * page (FR-008/FR-016). Deliberately generic -- gives no hint whether the
+ * requested id was invalid or simply belongs to a private series.
+ */
+export default function PublicSeriesNotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <h1 className="text-2xl font-bold">Series not found</h1>
+      <p className="mt-2 max-w-md" style={{ color: 'var(--fgColor-muted)' }}>
+        This page doesn&apos;t exist, or the series is no longer publicly available.
+      </p>
+      <Link
+        href="/"
+        className="mt-6 text-sm font-medium"
+        style={{ color: 'var(--fgColor-accent)' }}
+      >
+        Go to homepage
+      </Link>
+    </div>
+  )
+}

--- a/src/frontend/app/public/series/[id]/page.tsx
+++ b/src/frontend/app/public/series/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from 'next/navigation'
+import { getPublicSeries } from '@/lib/api/public-series'
+import { PublicSeriesLanding } from '@/components/public-series-landing'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: Props) {
+  const { id } = await params
+  const series = await getPublicSeries(id)
+  if (!series) return { title: 'Series not found — EnableFront Builder' }
+  return { title: `${series.title} — EnableFront Builder` }
+}
+
+/**
+ * Public, anonymous landing page for a series (FR-001/FR-002). No auth
+ * check of any kind is performed here -- visibility is entirely gated
+ * server-side by `GET /api/v1/public/series/{id}`, which returns 404 for
+ * both a nonexistent series and one with `IsPublic == false` (FR-016).
+ */
+export default async function PublicSeriesPage({ params }: Props) {
+  const { id } = await params
+  const series = await getPublicSeries(id)
+
+  if (!series) {
+    notFound()
+  }
+
+  return <PublicSeriesLanding series={series} />
+}

--- a/src/frontend/components/app-header.tsx
+++ b/src/frontend/components/app-header.tsx
@@ -13,8 +13,10 @@ export default function AppHeader() {
   const pathname = usePathname()
   const { mode, toggle } = useColorMode()
 
-  // Hide the header on the login page — it has its own branding
-  if (pathname === '/login') return null
+  // Hide the header on the login page and public series landing pages —
+  // both have their own distinct branding (FR-011) and must not surface any
+  // authenticated-app chrome to anonymous visitors.
+  if (pathname === '/login' || pathname?.startsWith('/public/')) return null
 
   return (
     <Header style={{ position: 'sticky', top: 0, zIndex: 30, width: '100%' }}>

--- a/src/frontend/components/public-series-landing.tsx
+++ b/src/frontend/components/public-series-landing.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import Image from 'next/image'
 import { LinkExternalIcon, CalendarIcon, ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react'
 import { hasSeriesDetails, renderSeriesDetailsHtml } from '@/lib/series-details-html'
 import type { PublicSeriesResponse } from '@/lib/api/types'
@@ -45,13 +44,11 @@ export function PublicSeriesLanding({ series }: Props) {
           already threaded through end-to-end so a future owner-facing image
           picker only needs to set that field -- no other changes required here. */}
       <div className="relative h-40 w-full overflow-hidden sm:h-56 md:h-64">
-        <Image
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
           src={series.imageUrl || DEFAULT_BANNER_SRC}
           alt=""
-          fill
-          priority
-          sizes="100vw"
-          className="object-cover"
+          className="h-full w-full object-cover"
         />
       </div>
 

--- a/src/frontend/components/public-series-landing.tsx
+++ b/src/frontend/components/public-series-landing.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { LinkExternalIcon, CalendarIcon, ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react'
+import { hasSeriesDetails, renderSeriesDetailsHtml } from '@/lib/series-details-html'
+import type { PublicSeriesResponse } from '@/lib/api/types'
+
+const DEFAULT_BANNER_SRC = '/series-banner-default.svg'
+
+function formatSessionDateTime(startsAt: string, endsAt: string) {
+  const start = new Date(startsAt)
+  const end = new Date(endsAt)
+  const date = start.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+  const startTime = start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+  const endTime = end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' })
+  return { date, time: `${startTime} – ${endTime}` }
+}
+
+/** A session has already ended when its `endsAt` is in the past (FR-013). */
+function hasEnded(endsAt: string): boolean {
+  return new Date(endsAt).getTime() < Date.now()
+}
+
+interface Props {
+  series: PublicSeriesResponse
+}
+
+/**
+ * Anonymous, read-only landing page for a public series. Deliberately styled
+ * distinct from the authenticated admin UI (FR-011) -- banner hero, card-based
+ * session list with expandable descriptions, no app header/chrome. Renders
+ * entirely from the `PublicSeriesResponse` payload; performs no mutations
+ * (FR-012).
+ */
+export function PublicSeriesLanding({ series }: Props) {
+  const sortedSessions = [...series.sessions].sort(
+    (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+  )
+  const [expandedSessionId, setExpandedSessionId] = useState<string | null>(null)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[var(--bgColor-accent-emphasis,#0969da)]/5 to-transparent">
+      {/* Banner: falls back to a bundled stock image today; `series.imageUrl` is
+          already threaded through end-to-end so a future owner-facing image
+          picker only needs to set that field -- no other changes required here. */}
+      <div className="relative h-40 w-full overflow-hidden sm:h-56 md:h-64">
+        <Image
+          src={series.imageUrl || DEFAULT_BANNER_SRC}
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover"
+        />
+      </div>
+
+      <div className="mx-auto max-w-3xl px-4 py-10 sm:py-16">
+        <header className="mb-10 text-center sm:mb-14">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-widest" style={{ color: 'var(--fgColor-accent)' }}>
+            Webinar Series
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{series.title}</h1>
+          {hasSeriesDetails(series.details) && (
+            <div className="mx-auto mt-4 max-w-2xl text-left text-base leading-relaxed [&_ul]:list-disc [&_ul]:pl-5 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_li]:mb-1" style={{ color: 'var(--fgColor-muted)' }}>
+              {renderSeriesDetailsHtml(series.details as string)}
+            </div>
+          )}
+        </header>
+
+        <section aria-label="Sessions">
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide" style={{ color: 'var(--fgColor-muted)' }}>
+            Sessions
+          </h2>
+
+          {sortedSessions.length === 0 ? (
+            <div
+              className="rounded-xl px-6 py-12 text-center"
+              style={{
+                border: '1px solid var(--borderColor-default)',
+                backgroundColor: 'var(--bgColor-default)',
+                color: 'var(--fgColor-muted)',
+              }}
+            >
+              <p>No sessions have been scheduled yet. Check back soon.</p>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-3">
+              {sortedSessions.map((s) => {
+                const { date, time } = formatSessionDateTime(s.startsAt, s.endsAt)
+                const ended = hasEnded(s.endsAt)
+                const hasDescription = hasSeriesDetails(s.description)
+                const isExpanded = expandedSessionId === s.sessionId
+
+                return (
+                  <li
+                    key={s.sessionId}
+                    className="rounded-xl p-4 sm:p-5"
+                    style={{
+                      border: '1px solid var(--borderColor-default)',
+                      backgroundColor: 'var(--bgColor-default)',
+                    }}
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <button
+                        type="button"
+                        disabled={!hasDescription}
+                        onClick={() => setExpandedSessionId(isExpanded ? null : s.sessionId)}
+                        aria-expanded={hasDescription ? isExpanded : undefined}
+                        className="min-w-0 flex-1 text-left disabled:cursor-default"
+                      >
+                        <p className="flex items-center gap-1.5 font-semibold">
+                          <span className="truncate">{s.title}</span>
+                          {hasDescription && (
+                            isExpanded ? (
+                              <ChevronUpIcon size={16} className="shrink-0" />
+                            ) : (
+                              <ChevronDownIcon size={16} className="shrink-0" />
+                            )
+                          )}
+                        </p>
+                        <p className="mt-1 flex items-center gap-1.5 text-sm" style={{ color: 'var(--fgColor-muted)' }}>
+                          <CalendarIcon size={14} />
+                          {date} · {time}
+                          {ended && <span className="ml-1 italic">(past)</span>}
+                        </p>
+                      </button>
+
+                      {s.registrationUrl && !ended && (
+                        <a
+                          href={s.registrationUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90"
+                          style={{
+                            backgroundColor: 'var(--bgColor-accent-emphasis)',
+                            color: 'var(--fgColor-onEmphasis)',
+                          }}
+                        >
+                          Register <LinkExternalIcon size={14} />
+                        </a>
+                      )}
+                    </div>
+
+                    {hasDescription && isExpanded && (
+                      <div
+                        className="mt-3 max-w-none border-t pt-3 text-sm leading-relaxed [&_ul]:list-disc [&_ul]:pl-5 [&_p]:mb-2 [&_p:last-child]:mb-0 [&_li]:mb-1"
+                        style={{ borderColor: 'var(--borderColor-default)', color: 'var(--fgColor-muted)' }}
+                      >
+                        {renderSeriesDetailsHtml(s.description as string)}
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+

--- a/src/frontend/components/series-detail-view.tsx
+++ b/src/frontend/components/series-detail-view.tsx
@@ -10,6 +10,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { InlineEditableTitle } from '@/components/inline-editable-title'
 import { SeriesDetails } from '@/components/series-details'
+import { SeriesVisibilityToggle } from '@/components/series-visibility-toggle'
 import { MetricsPanel } from '@/components/metrics-panel'
 import { updateSeries, deleteSeries, exportSeriesMarkdown } from '@/lib/api/series'
 import { deleteSession } from '@/lib/api/sessions'
@@ -107,6 +108,29 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
   const [seriesDetails, setSeriesDetails] = useState<string | null>(series.details)
   const [detailsLoading, setDetailsLoading] = useState(false)
   const [detailsError, setDetailsError] = useState<string | null>(null)
+
+  const [isPublic, setIsPublic] = useState(series.isPublic)
+  const [publicUrl, setPublicUrl] = useState('')
+
+  useEffect(() => {
+    setIsPublic(series.isPublic)
+  }, [series.isPublic])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setPublicUrl(`${window.location.origin}/public/series/${series.seriesId}`)
+    }
+  }, [series.seriesId])
+
+  async function handleVisibilityChange(nextIsPublic: boolean) {
+    await updateSeries(
+      series.seriesId,
+      { title: seriesTitle, details: seriesDetails ?? undefined, isPublic: nextIsPublic },
+      token,
+    )
+    setIsPublic(nextIsPublic)
+    router.refresh()
+  }
 
   // The backend only ever returns/updates a series for its owner (see
   // specs/001-series-details/research.md Decision 4) -- there is no
@@ -241,6 +265,13 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
         canEdit={canEditDetails}
         onSave={handleDetailsSave}
         saving={detailsLoading}
+        disabled={busy}
+      />
+
+      <SeriesVisibilityToggle
+        checked={isPublic}
+        publicUrl={publicUrl}
+        onChange={handleVisibilityChange}
         disabled={busy}
       />
 

--- a/src/frontend/components/series-detail-view.tsx
+++ b/src/frontend/components/series-detail-view.tsx
@@ -84,7 +84,7 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
 
   const [editLoading, setEditLoading] = useState(false)
   const [editError, setEditError] = useState<string | null>(null)
-  const busy = sessionStatus === 'loading' || editLoading
+  const [visibilityLoading, setVisibilityLoading] = useState(false)
 
   useEffect(() => {
     setSeriesTitle(series.title)
@@ -108,6 +108,7 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
   const [seriesDetails, setSeriesDetails] = useState<string | null>(series.details)
   const [detailsLoading, setDetailsLoading] = useState(false)
   const [detailsError, setDetailsError] = useState<string | null>(null)
+  const busy = sessionStatus === 'loading' || editLoading || detailsLoading || visibilityLoading
 
   const [isPublic, setIsPublic] = useState(series.isPublic)
   const [publicUrl, setPublicUrl] = useState('')
@@ -123,13 +124,18 @@ export default function SeriesDetailView({ series, sessions, metrics }: Props) {
   }, [series.seriesId])
 
   async function handleVisibilityChange(nextIsPublic: boolean) {
-    await updateSeries(
-      series.seriesId,
-      { title: seriesTitle, details: seriesDetails ?? undefined, isPublic: nextIsPublic },
-      token,
-    )
-    setIsPublic(nextIsPublic)
-    router.refresh()
+    setVisibilityLoading(true)
+    try {
+      await updateSeries(
+        series.seriesId,
+        { title: seriesTitle, details: seriesDetails ?? undefined, isPublic: nextIsPublic },
+        token,
+      )
+      setIsPublic(nextIsPublic)
+      router.refresh()
+    } finally {
+      setVisibilityLoading(false)
+    }
   }
 
   // The backend only ever returns/updates a series for its owner (see

--- a/src/frontend/components/series-visibility-toggle.tsx
+++ b/src/frontend/components/series-visibility-toggle.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useId, useState } from 'react'
+import { ToggleSwitch } from '@primer/react'
+import { LinkExternalIcon } from '@primer/octicons-react'
+
+export interface SeriesVisibilityToggleProps {
+  /** Current `IsPublic` state, as last confirmed by the server. */
+  checked: boolean
+  /** Absolute public landing page URL, shown only while `checked` is true. */
+  publicUrl: string
+  /** Persists the new value; throwing leaves the toggle at its prior state. */
+  onChange: (nextChecked: boolean) => Promise<void>
+  disabled?: boolean
+}
+
+/**
+ * Owner-facing on/off control for the public series landing page
+ * (`/public/series/{id}`). Off by default (FR-013/FR-014) -- this component
+ * only ever reflects and changes the series' `isPublic` flag; it never
+ * infers visibility from anything else.
+ */
+export function SeriesVisibilityToggle({
+  checked,
+  publicUrl,
+  onChange,
+  disabled = false,
+}: SeriesVisibilityToggleProps) {
+  const labelId = useId()
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleClick() {
+    const next = !checked
+    setPending(true)
+    setError(null)
+    try {
+      await onChange(next)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update visibility')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <ToggleSwitch
+          aria-labelledby={labelId}
+          checked={checked}
+          onClick={handleClick}
+          disabled={disabled || pending}
+          size="small"
+        />
+        <span id={labelId} className="text-sm font-medium">
+          Public landing page
+        </span>
+        {checked && (
+          <a
+            href={publicUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs"
+            style={{ color: 'var(--fgColor-accent)' }}
+          >
+            View page <LinkExternalIcon size={12} />
+          </a>
+        )}
+      </div>
+      {error && (
+        <p className="text-xs" style={{ color: 'var(--fgColor-danger)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/frontend/components/series-visibility-toggle.tsx
+++ b/src/frontend/components/series-visibility-toggle.tsx
@@ -69,7 +69,7 @@ export function SeriesVisibilityToggle({
         )}
       </div>
       {error && (
-        <p className="text-xs" style={{ color: 'var(--fgColor-danger)' }}>
+        <p role="alert" className="text-xs" style={{ color: 'var(--fgColor-danger)' }}>
           {error}
         </p>
       )}

--- a/src/frontend/e2e/public-series-landing.spec.ts
+++ b/src/frontend/e2e/public-series-landing.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E tests for the anonymous public series landing page
+ * (`/public/series/[id]`, backed by `GET /api/v1/public/series/{id}`).
+ *
+ * Unlike the authenticated series pages, this route requires no session
+ * cookie at all -- it must be reachable with a cold, unauthenticated
+ * browser context. The Next.js server component fetches
+ * `GET /api/v1/public/series/:id` directly from the Node server process,
+ * which is not interceptable by Playwright's `page.route()` (that only
+ * intercepts browser-originated requests). We rely on
+ * `BACKEND_API_BASE_URL`/`NEXT_PUBLIC_BACKEND_API_BASE_URL` pointing at a
+ * reachable backend (or local stub) for these tests to pass; see
+ * `series-export.spec.ts` for the same caveat on other pages.
+ */
+import { test, expect } from '@playwright/test'
+
+const PUBLIC_SERIES_ID = 'e2e-public-series-001'
+const PRIVATE_SERIES_ID = 'e2e-private-series-001'
+const EMPTY_DETAILS_SERIES_ID = 'e2e-empty-details-series-001'
+const NO_SESSIONS_SERIES_ID = 'e2e-no-sessions-series-001'
+
+test.describe('Public series landing page', () => {
+  test('is reachable without any authentication cookie', async ({ browser }) => {
+    // Explicitly create a context with zero cookies/storage state to prove
+    // the route never redirects to /login (FR-002).
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    const response = await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+    expect(response?.status()).not.toBe(401)
+    expect(response?.status()).not.toBe(403)
+    expect(page.url()).not.toContain('/login')
+    expect(page.url()).not.toContain('/api/auth/signin')
+
+    await context.close()
+  })
+
+  test('shows a generic not-found state for a nonexistent series id', async ({ page }) => {
+    await page.goto('/public/series/00000000-0000-0000-0000-000000000000')
+    await expect(page.getByRole('heading', { name: 'Series not found' })).toBeVisible()
+  })
+
+  // The remaining scenarios (T024-T026, T037-T039, T041-T043) require the
+  // backend to actually serve the fixture series ids above with the
+  // corresponding IsPublic/details/sessions state, since the page.tsx server
+  // component's fetch runs in the Node dev-server process and is not
+  // interceptable by page.route() (see series-export.spec.ts for the same
+  // documented limitation). They are written to run against a live backend
+  // or local stub seeded with these fixture ids.
+
+  test('renders title, details, and session table for a public series', async ({ page }) => {
+    await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+    await expect(page.getByRole('link', { name: /Register/i }).first()).toBeVisible()
+  })
+
+  test('renders cleanly with no broken description section when Details is empty', async ({ page }) => {
+    await page.goto(`/public/series/${EMPTY_DETAILS_SERIES_ID}`)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+  })
+
+  test('shows a neutral empty-state message when a public series has zero sessions', async ({ page }) => {
+    await page.goto(`/public/series/${NO_SESSIONS_SERIES_ID}`)
+    await expect(page.getByText('No sessions have been scheduled yet.')).toBeVisible()
+  })
+
+  test('a private series renders the identical not-found page as a nonexistent id', async ({ page }) => {
+    await page.goto(`/public/series/${PRIVATE_SERIES_ID}`)
+    await expect(page.getByRole('heading', { name: 'Series not found' })).toBeVisible()
+  })
+
+  test('a session with a registrationUrl shows a Register control opening in a new tab', async ({ page, context }) => {
+    await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+    const registerLink = page.getByRole('link', { name: /Register/i }).first()
+    await expect(registerLink).toHaveAttribute('target', '_blank')
+    await expect(registerLink).toHaveAttribute('rel', 'noopener noreferrer')
+    void context // new-tab behavior is implied by target="_blank"+rel, verified via attributes above
+  })
+
+  test('sessions with an ended endsAt show no active Register control', async ({ page }) => {
+    await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+    await expect(page.getByText('(past)').first()).toBeVisible()
+  })
+
+  test('mobile viewport (~375px) has no horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    )
+    expect(hasOverflow).toBe(false)
+  })
+
+  test('tablet (~768px) and desktop (~1280px) viewports have no horizontal overflow', async ({ page }) => {
+    for (const width of [768, 1280]) {
+      await page.setViewportSize({ width, height: 900 })
+      await page.goto(`/public/series/${PUBLIC_SERIES_ID}`)
+      const hasOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      )
+      expect(hasOverflow).toBe(false)
+    }
+  })
+})
+

--- a/src/frontend/lib/api/public-series.ts
+++ b/src/frontend/lib/api/public-series.ts
@@ -1,0 +1,20 @@
+import { apiFetch, ApiError } from './client'
+import type { PublicSeriesResponse } from './types'
+
+/**
+ * Fetches the anonymous public landing page payload for a series.
+ *
+ * Unlike every other `lib/api` call, this hits `/api/v1/public/series/{id}`
+ * and is never passed an access token -- the endpoint is unauthenticated by
+ * design (see `specs/004-public-series-landing-page/contracts/public-series-api.md`).
+ * Returns `null` for a `404` (series doesn't exist or is not public) so the
+ * caller can render a not-found page without treating it as an error.
+ */
+export async function getPublicSeries(id: string): Promise<PublicSeriesResponse | null> {
+  try {
+    return await apiFetch<PublicSeriesResponse>(`/public/series/${id}`)
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null
+    throw err
+  }
+}

--- a/src/frontend/lib/api/series.ts
+++ b/src/frontend/lib/api/series.ts
@@ -25,7 +25,7 @@ export async function createSeries(
 
 export async function updateSeries(
   id: string,
-  data: { title: string; details?: string | null },
+  data: { title: string; details?: string | null; isPublic?: boolean },
   accessToken: string,
 ): Promise<SeriesResponse> {
   return apiFetch<SeriesResponse>(

--- a/src/frontend/lib/api/types.ts
+++ b/src/frontend/lib/api/types.ts
@@ -13,6 +13,8 @@ export interface SeriesResponse {
   seriesId: string
   title: string
   details: string | null
+  isPublic: boolean
+  imageUrl: string | null
   createdAt: string
   updatedAt: string
 }
@@ -36,6 +38,22 @@ export interface SessionResponse {
   endsAt: string
   registrationUrl: string | null
   description: string | null
+}
+
+export interface PublicSessionItem {
+  sessionId: string
+  title: string
+  startsAt: string
+  endsAt: string
+  registrationUrl: string | null
+  description: string | null
+}
+
+export interface PublicSeriesResponse {
+  title: string
+  details: string | null
+  imageUrl: string | null
+  sessions: PublicSessionItem[]
 }
 
 export interface SeriesMetricsResponse {

--- a/src/frontend/proxy.ts
+++ b/src/frontend/proxy.ts
@@ -17,7 +17,7 @@ export async function proxy(req: NextRequest) {
     pathname.startsWith('/api/auth') ||
     pathname.startsWith('/login') ||
     pathname.startsWith('/about') ||
-    pathname.startsWith('/public') ||
+    (pathname === '/public' || pathname.startsWith('/public/')) ||
     pathname.startsWith('/_next') ||
     pathname === '/favicon.ico'
   ) {

--- a/src/frontend/proxy.ts
+++ b/src/frontend/proxy.ts
@@ -5,17 +5,19 @@ import { getToken } from 'next-auth/jwt'
  * Proxy (previously "middleware") — protects all routes except:
  * - /api/auth/... (next-auth internal routes)
  * - /login       (sign-in page)
+ * - /public/...  (anonymous public pages, e.g. public series landing)
  * - Next.js static files and image optimisation
  * - favicon
  */
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl
 
-  // Allow auth and login routes through unconditionally
+  // Allow auth, login, and public routes through unconditionally
   if (
     pathname.startsWith('/api/auth') ||
     pathname.startsWith('/login') ||
     pathname.startsWith('/about') ||
+    pathname.startsWith('/public') ||
     pathname.startsWith('/_next') ||
     pathname === '/favicon.ico'
   ) {
@@ -34,6 +36,6 @@ export async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api/auth|login|_next/static|_next/image|favicon\\.ico).*)',
+    '/((?!api/auth|login|public|_next/static|_next/image|favicon\\.ico).*)',
   ],
 }

--- a/src/frontend/proxy.ts
+++ b/src/frontend/proxy.ts
@@ -36,6 +36,6 @@ export async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api/auth|login|public|_next/static|_next/image|favicon\\.ico).*)',
+    '/((?!api/auth|login|public(?:/|$)|_next/static|_next/image|favicon\\.ico).*)',
   ],
 }

--- a/src/frontend/public/series-banner-default.svg
+++ b/src/frontend/public/series-banner-default.svg
@@ -1,0 +1,18 @@
+<svg width="1200" height="400" viewBox="0 0 1200 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Default series banner">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0969da" />
+      <stop offset="100%" stop-color="#54aeff" />
+    </linearGradient>
+    <pattern id="dots" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="rgba(255,255,255,0.18)" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="400" fill="url(#g)" />
+  <rect width="1200" height="400" fill="url(#dots)" />
+  <g fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="2">
+    <circle cx="150" cy="90" r="46" />
+    <circle cx="1060" cy="310" r="70" />
+    <circle cx="980" cy="70" r="24" />
+  </g>
+</svg>

--- a/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs
+++ b/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/Public/PublicSeriesEndpointsTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using EnableFront.Builder.Common;
+using EnableFront.Builder.Features.Series.Dtos;
+using EnableFront.Builder.Features.Series.Public.Dtos;
+using FluentAssertions;
+
+namespace EnableFront.Builder.Api.Tests.Features.Series.Public;
+
+/// <summary>
+/// API contract tests for the anonymous public series landing page endpoint
+/// (<c>GET /api/v1/public/series/{id}</c>), exercised end-to-end through the real minimal API
+/// pipeline via <see cref="SeriesApiWebApplicationFactory"/>. See
+/// specs/004-public-series-landing-page/contracts/public-series-api.md.
+/// </summary>
+public sealed class PublicSeriesEndpointsTests : IDisposable
+{
+    private const string OwnerOid = "public-contract-owner-oid";
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly SeriesApiWebApplicationFactory _factory = new();
+    private readonly HttpClient _ownerClient;
+    private readonly HttpClient _anonymousClient;
+
+    public PublicSeriesEndpointsTests()
+    {
+        _ownerClient = _factory.CreateClient();
+        _ownerClient.DefaultRequestHeaders.Add(TestAuthHandler.OidHeaderName, OwnerOid);
+        _anonymousClient = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _ownerClient.Dispose();
+        _anonymousClient.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task Get_ReturnsOk_WithTitleDetailsAndSessions_WhenSeriesIsPublic()
+    {
+        var series = await CreatePublicSeriesAsync("Public Series", "<p>Details</p>");
+        await CreateSessionAsync(series.SeriesId, "Session 1", "https://example.com/register");
+
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{series.SeriesId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PublicSeriesResponseDto>(JsonOptions);
+        body!.Title.Should().Be("Public Series");
+        body.Details.Should().Be("<p>Details</p>");
+        body.Sessions.Should().ContainSingle(s => s.Title == "Session 1" && s.RegistrationUrl == "https://example.com/register");
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_WithSeriesNotFoundShape_WhenSeriesIsPrivate()
+    {
+        var series = await CreatePrivateSeriesAsync("Private Series");
+
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{series.SeriesId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ErrorEnvelope>(JsonOptions);
+        error!.ErrorCode.Should().Be("series_not_found");
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_WithIdenticalShape_WhenSeriesDoesNotExist()
+    {
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ErrorEnvelope>(JsonOptions);
+        error!.ErrorCode.Should().Be("series_not_found");
+    }
+
+    [Fact]
+    public async Task Get_ResponseBody_NeverContainsOwnerOrSeriesIdOrIsPublicOrMetricsFields()
+    {
+        var series = await CreatePublicSeriesAsync("Public Series", null);
+
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{series.SeriesId}");
+        var rawJson = await response.Content.ReadAsStringAsync();
+
+        rawJson.Should().NotContainEquivalentOf("ownerUserId");
+        rawJson.Should().NotContainEquivalentOf("seriesId");
+        rawJson.Should().NotContainEquivalentOf("isPublic");
+        rawJson.Should().NotContainEquivalentOf("totalRegistrations");
+        rawJson.Should().NotContainEquivalentOf("totalAttendees");
+    }
+
+    [Fact]
+    public async Task Get_IsReachable_WithNoAuthorizationHeaderOrCookie()
+    {
+        var series = await CreatePublicSeriesAsync("Public Series", null);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/public/series/{series.SeriesId}");
+        using var response = await _anonymousClient.SendAsync(request);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNullDetails_AndEmptySessions_ForMinimalPublicSeries()
+    {
+        var series = await CreatePublicSeriesAsync("Minimal Series", null);
+
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{series.SeriesId}");
+        var body = await response.Content.ReadFromJsonAsync<PublicSeriesResponseDto>(JsonOptions);
+
+        body!.Details.Should().BeNull();
+        body.Sessions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Get_IncludesSessionsWithNoRegistrationUrl_AsNullRegistrationUrl()
+    {
+        var series = await CreatePublicSeriesAsync("Public Series", null);
+        await CreateSessionAsync(series.SeriesId, "No Registration Session", registrationUrl: null);
+
+        var response = await _anonymousClient.GetAsync($"/api/v1/public/series/{series.SeriesId}");
+        var body = await response.Content.ReadFromJsonAsync<PublicSeriesResponseDto>(JsonOptions);
+
+        body!.Sessions.Should().ContainSingle(s => s.Title == "No Registration Session" && s.RegistrationUrl == null);
+    }
+
+    // ---------- Helpers ----------
+
+    private async Task<SeriesResponseDto> CreatePublicSeriesAsync(string title, string? details)
+    {
+        var created = await CreateSeriesAsync(title, details);
+        var putResponse = await _ownerClient.PutAsJsonAsync(
+            $"/api/v1/series/{created.SeriesId}", new UpdateSeriesRequest(title, details, IsPublic: true));
+        putResponse.EnsureSuccessStatusCode();
+        return (await putResponse.Content.ReadFromJsonAsync<SeriesResponseDto>(JsonOptions))!;
+    }
+
+    private async Task<SeriesResponseDto> CreatePrivateSeriesAsync(string title) =>
+        await CreateSeriesAsync(title, null);
+
+    private async Task<SeriesResponseDto> CreateSeriesAsync(string title, string? details)
+    {
+        var response = await _ownerClient.PostAsJsonAsync("/api/v1/series", new CreateSeriesRequest(title, details));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<SeriesResponseDto>(JsonOptions))!;
+    }
+
+    private async Task CreateSessionAsync(Guid seriesId, string title, string? registrationUrl)
+    {
+        var response = await _ownerClient.PostAsJsonAsync(
+            $"/api/v1/series/{seriesId}/sessions",
+            new
+            {
+                Title = title,
+                StartsAt = DateTime.UtcNow.AddDays(1),
+                EndsAt = DateTime.UtcNow.AddDays(1).AddHours(1),
+                RegistrationUrl = registrationUrl
+            });
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesDetailsApiContractTests.cs
+++ b/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesDetailsApiContractTests.cs
@@ -136,6 +136,48 @@ public sealed class SeriesDetailsApiContractTests : IDisposable
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    [Fact]
+    public async Task Get_ReturnsIsPublic_InResponseBody()
+    {
+        var created = await CreateSeriesAsync("Visibility Series", null);
+
+        var getResponse = await _ownerClient.GetAsync($"/api/v1/series/{created.SeriesId}");
+        var fetched = await getResponse.Content.ReadFromJsonAsync<SeriesResponseDto>(JsonOptions);
+
+        fetched!.IsPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Put_PersistsIsPublic_AndReturnsItInResponseBody()
+    {
+        var created = await CreateSeriesAsync("Visibility Series", null);
+
+        var putResponse = await _ownerClient.PutAsJsonAsync(
+            $"/api/v1/series/{created.SeriesId}", new UpdateSeriesRequest(created.Title, IsPublic: true));
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await putResponse.Content.ReadFromJsonAsync<SeriesResponseDto>(JsonOptions);
+        updated!.IsPublic.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Put_ReturnsNotFound_ForNonOwner_SoIsPublicCannotBeChangedByOthers()
+    {
+        var created = await CreateSeriesAsync("Owner Only Series", null);
+
+        using var otherClient = _factory.CreateClient();
+        otherClient.DefaultRequestHeaders.Add(TestAuthHandler.OidHeaderName, OtherOid);
+
+        var response = await otherClient.PutAsJsonAsync(
+            $"/api/v1/series/{created.SeriesId}", new UpdateSeriesRequest(created.Title, IsPublic: true));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var getResponse = await _ownerClient.GetAsync($"/api/v1/series/{created.SeriesId}");
+        var fetched = await getResponse.Content.ReadFromJsonAsync<SeriesResponseDto>(JsonOptions);
+        fetched!.IsPublic.Should().BeFalse("a non-owner PUT must not change visibility");
+    }
+
     private async Task<SeriesResponseDto> CreateSeriesAsync(string title, string? details)
     {
         var response = await _ownerClient.PostAsJsonAsync("/api/v1/series", new CreateSeriesRequest(title, details));

--- a/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesServiceTests.cs
+++ b/tests/backend/EnableFront.Builder.Api.Tests/Features/Series/SeriesServiceTests.cs
@@ -193,6 +193,65 @@ public class SeriesServiceTests : IDisposable
         result.Should().BeNull();
     }
 
+    // ---------- IsPublic (visibility toggle) ----------
+
+    [Fact]
+    public async Task CreateAsync_DefaultsIsPublic_ToFalse()
+    {
+        var result = await _sut.CreateAsync(new CreateSeriesRequest("New Series"), OwnerUserId);
+
+        result.IsPublic.Should().BeFalse();
+
+        var saved = await _db.Series.FindAsync(result.SeriesId);
+        saved!.IsPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsIsPublic_FalseToTrue()
+    {
+        var series = BuildSeries("Alpha", OwnerUserId);
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.UpdateAsync(
+            series.SeriesId, new UpdateSeriesRequest("Alpha", IsPublic: true), OwnerUserId);
+
+        result!.IsPublic.Should().BeTrue();
+        var saved = await _db.Series.FindAsync(series.SeriesId);
+        saved!.IsPublic.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsIsPublic_TrueToFalse()
+    {
+        var series = BuildSeries("Alpha", OwnerUserId);
+        series.IsPublic = true;
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.UpdateAsync(
+            series.SeriesId, new UpdateSeriesRequest("Alpha", IsPublic: false), OwnerUserId);
+
+        result!.IsPublic.Should().BeFalse();
+        var saved = await _db.Series.FindAsync(series.SeriesId);
+        saved!.IsPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PreservesStoredIsPublic_WhenRequestOmitsField()
+    {
+        var series = BuildSeries("Alpha", OwnerUserId);
+        series.IsPublic = true;
+        _db.Series.Add(series);
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.UpdateAsync(series.SeriesId, new UpdateSeriesRequest("Alpha Renamed"), OwnerUserId);
+
+        result!.IsPublic.Should().BeTrue("omitting IsPublic on an unrelated save must not reset visibility");
+        var saved = await _db.Series.FindAsync(series.SeriesId);
+        saved!.IsPublic.Should().BeTrue();
+    }
+
     [Fact]
     public async Task UpdateAsync_SetsUpdatedAt_AfterOriginalCreation()
     {


### PR DESCRIPTION
## Why

Series owners need a way to share a professional, anonymous-facing landing page for a series so registrants can view session details and register without needing an account. Owners should control when this page is public.

## What changed

- **New anonymous route** `/public/series/[id]` (keyed by the existing GUID series ID for obfuscation) rendering series title, details, and a list of sessions with registration links. No auth required, no mutations performed.
- **Owner-controlled visibility**: `Series.IsPublic` flag, defaulting to `false`, toggled from the admin series detail view (`series-visibility-toggle.tsx`). Public endpoint returns 404 when the series is private or missing.
- **Banner image**: `Series.ImageUrl` (nullable) threaded through the public and owner-facing DTOs. The landing page renders a bundled stock SVG banner when unset, so a future owner-facing image picker only needs to populate this field -- no other plumbing required.
- **Expandable session rows**: each session row can be expanded to reveal its (already-existing) rich-text description above the Register button, so registrants can read about a session before committing.

## Implementation notes

- New minimal-API feature slice under `Features/Series/Public/` (endpoints, service, DTOs) kept separate from the authenticated `Series` feature to avoid leaking owner-only data (no `ownerUserId`, `seriesId`, `isPublic`, or metrics fields in the public payload).
- Two EF Core migrations: `AddIsPublicToSeries` and `AddImageUrlToSeries`.
- Frontend: new `app/public/series/[id]` route tree (page/loading/not-found), `lib/api/public-series.ts` client, and `public-series-landing.tsx` component reusing the existing sanitized-HTML rendering pattern from session descriptions.
- Full spec/plan/tasks under `specs/004-public-series-landing-page/`.

## Testing

- Backend: full suite passes (239/239), including new `PublicSeriesEndpointsTests`.
- Frontend: `tsc --noEmit`, `npm run lint`, and `npm run build` all pass.
- E2E spec added (`e2e/public-series-landing.spec.ts`); requires a live/seeded backend to run fully.